### PR TITLE
Revert cachlib to 0.9.0 to resolve conflict with flask_cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aniso8601==9.0.1
 blinker==1.6.2
 Brotli==1.1.0
-cachelib==0.10.2
+cachelib==0.9.0
 certifi==2023.7.22
 charset-normalizer==3.2.0
 click==8.1.7


### PR DESCRIPTION
Flask Cache currently relies on cachelib < 0.10.0. Reverting as this will cause build failure.