### PR TITLE
Add unit tests and fix flask cache deprecation

### DIFF
--- a/kevin.py
+++ b/kevin.py
@@ -37,20 +37,18 @@ init_cache(app)
 
 #Function for sanitizing input
 def sanitize_query(query):
-    if query is None:
+    # Convert the query to a string, in case it's an integer
+    query = str(query)
+    if query == 'None':
         return None
-
-    # Check if the query is an integer, if so, return it without any modifications
-    if isinstance(query, int):
-        return query
-
     # URL decode the query
     query = unquote(query)
-    # Allow alphanumeric characters, spaces, and common punctuation
+    # Allow alphanumeric characters, spaces, and hyphens
     query = re.sub(r"[^a-zA-Z0-9\s-]", "", query)
     # Remove extra whitespace from query
     query = query.strip()
     query = re.sub(r"\s+", " ", query)
+    # Finally, return the sanitized query
     return query
 
 # Route for the root endpoint ("/")

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import pytest
+from kevin import sanitize_query
+
+def test_sanitize_query():
+    assert sanitize_query("abc123") == "abc123"
+    assert sanitize_query("abc 123") == "abc 123"
+    assert sanitize_query("abc-123") == "abc-123"
+    assert sanitize_query("abc@123") == "abc123"
+    assert sanitize_query(None) == None
+    assert sanitize_query(123) == "123"
+
+    # Test for potential MongoDB injection attacks
+    assert sanitize_query("{$ne: null}") == "ne null"
+    assert sanitize_query("{ $where: 'this.a > this.b' }") == "where thisa thisb"
+
+    # Test for URL encoded values
+    assert sanitize_query("%20") == ""
+    assert sanitize_query("%3Cscript%3E") == "script"
+
+    # Additional tests for malicious input
+    assert sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
+    assert sanitize_query("1; DROP TABLE users") == "1 DROP TABLE users"
+    assert sanitize_query("admin' --") == "admin --"
+    assert sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom targetblankLinka"

--- a/utils/cache_config.py
+++ b/utils/cache_config.py
@@ -8,7 +8,7 @@ load_dotenv()
 REDIS_IP = os.getenv("REDIS_IP")
 
 cache_config = {
-    'CACHE_TYPE': 'redis',
+    'CACHE_TYPE': 'flask_caching.backends.RedisCache',
     'CACHE_DEFAULT_TIMEOUT': 600,
     'CACHE_REDIS_HOST': REDIS_IP,
     'CACHE_REDIS_PORT': '6379',


### PR DESCRIPTION
Aside from fixing deprecation, we've also identified that we should have been converting ints to strings during the sanitization process. 