### PR TITLE
Support lowercase cve, update tests

### DIFF
--- a/kevin.py
+++ b/kevin.py
@@ -50,6 +50,7 @@ def sanitize_query(query):
             query = decoded_query
     # Allow alphanumeric characters, spaces, and hyphens
     query = re.sub(r"[^a-zA-Z0-9\s-]", "", query)
+    query = re.sub(r'\bcve\b', 'CVE', query, flags=re.IGNORECASE)
     # Remove extra whitespace from query
     query = query.strip()
     query = re.sub(r"\s+", " ", query)

--- a/schema/api.py
+++ b/schema/api.py
@@ -31,6 +31,7 @@ def sanitize_query(query):
             query = decoded_query
     # Allow alphanumeric characters, spaces, and hyphens
     query = re.sub(r"[^a-zA-Z0-9\s-]", "", query)
+    query = re.sub(r'\bcve\b', 'CVE', query, flags=re.IGNORECASE)
     # Remove extra whitespace from query
     query = query.strip()
     query = re.sub(r"\s+", " ", query)

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -11,6 +11,9 @@ def test_sanitize_query():
     assert sanitize_query("abc@123") == "abc123"
     assert sanitize_query(None) == None
     assert sanitize_query(123) == "123"
+    assert sanitize_query("CVE-1234-123456") == "CVE-1234-123456"
+    assert sanitize_query("cve-1234-123456") == "CVE-1234-123456"
+    
 
     # Test for potential MongoDB injection attacks
     assert sanitize_query("{$ne: null}") == "ne null"
@@ -37,6 +40,8 @@ def test_api_sanitize_query():
     assert api_sanitize_query("abc@123") == "abc123"
     assert api_sanitize_query(None) == None
     assert api_sanitize_query(123) == "123"
+    assert api_sanitize_query("CVE-1234-123456") == "CVE-1234-123456"
+    assert api_sanitize_query("cve-1234-123456") == "CVE-1234-123456"
 
     # Test for potential MongoDB injection attacks
     assert api_sanitize_query("{$ne: null}") == "ne null"


### PR DESCRIPTION
Ensure that if a user submits lowercase cve, that we convert it to capital. This makes it no longer required to enter capital CVE. 