### PR TITLE
Add ransomware filter to KEV

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,7 @@
                         <ul>
                             <li><a href="/kev" target="_blank">/kev</a> - Get the most recently added KEVs</li>
                             <li><a href="/kev/exists?cve=CVE-2023-22527" target="_blank">/kev/exists?cve=CVE-2023-22527</a> - Get a bool value if a CVE is in the KEV or not.</li>
+                            <li><a href="/kev?filter=ransomware" target="_blank">/kev?filter=ransomware</a> - Filter by vulnerabilities known to be used in ransomware</li>
                             <li><a href="/kev?page=1&per_page=25" target="_blank">/kev?page=1&per_page=25</a> - Get the first 25 Known Exploited Vulnerabilities (default pagination)</li>
                             <li><a href="/kev?page=2&per_page=25" target="_blank">/kev?page=2&per_page=25</a> - Get the next 25 Known Exploited Vulnerabilities (default pagination)</li>
                             <li><a href="/kev?search=Microsoft&page=1&per_page=10" target="_blank">/kev?search=Microsoft&page=1&per_page=10</a> - Search KEV based on description (first 10 results)</li>


### PR DESCRIPTION
Create the ability to view KEVs that have been indicated as observed in ransomware campaigns. 

New path/parameter: 

/kev?filter=ransomware 
