### PR TITLE
Adjust Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,27 @@
-# Use the official Python image as the base image
-FROM python:3.12
+# Use the official Python-slim image as the base image
+FROM python:3.12-slim
 
-# Set the working directory in the container
+# Set environment variables to prevent Python from writing pyc files and buffering stdout/stderr
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Install necessary system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the working directory
 WORKDIR /app
 
-# Copy the requirements file into the container
-COPY requirements.txt requirements.txt
+# Copy and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Install the required dependencies
-RUN pip install -r requirements.txt
-
-# Copy the entire application directory into the container
+# Copy the application code
 COPY . .
 
-# Expose the port that Gunicorn will listen on
+# Expose the original port (unchanged)
 EXPOSE 8444
 
-# Command to run Gunicorn with your Flask app
+# Command to run Gunicorn with flask
 CMD ["gunicorn", "--bind", "0.0.0.0:8444", "--workers", "4", "--worker-class", "gevent", "--timeout", "30", "--max-requests", "1000", "--max-requests-jitter", "50", "kevin:app"]


### PR DESCRIPTION
Adjusted to use Python 3.12-slim. Reduces image disk overhead from ~1.2GB to about 393MB. 