### PR TITLE
Add orjson for jsonify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 env/
+env2/
 __pycache__/
 *.py[cod]
 poc_processor.py

--- a/kevin.py
+++ b/kevin.py
@@ -29,6 +29,9 @@ from schema.api import (
 )
 from schema.serializers import serialize_vulnerability, serialize_all_vulnerability
 
+# Load the flask_orjson extension
+from flask_orjson import OrjsonProvider
+
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,10 @@ load_dotenv()
 
 # Initialize the Flask app and the Flask-RESTful API
 app = Flask(__name__)
+# Set the JSON provider to ORJSONProvider
+app.json_provider_class = OrjsonProvider
+# set app.json to the json_provider_class. This makes the app use ORJSONProvider for JSON serialization.
+app.json = app.json_provider_class(app)
 api = Api(app)
 
 # Enable GZIP compression for all routes

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ defusedxml==0.7.1
 dnspython==2.7.0
 Flask==3.0.3
 Flask-Compress==1.17
+flask-orjson==2.0.0
 Flask-RESTful==0.3.10
 gevent==25.4.1
 greenlet==3.2.0
@@ -18,6 +19,7 @@ iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==2.1.5
+orjson==3.10.18
 packaging==24.1
 pluggy==1.5.0
 pymongo==4.10.1


### PR DESCRIPTION
Switch Flask JSON provider to orjson for improved performance

- Replaced usage of ORJSONProvider with OrjsonProvider from flask_orjson to align with the updated package naming.
- Updated app.json_provider_class and related setup to use OrjsonProvider, ensuring all jsonify responses leverage orjson serialization.
- Confirmed all serializers and API endpoints are compatible with orjson (ObjectId and datetime are properly converted to strings). 
- No changes required to existing response or serializer logic; all JSON output is now faster and more standards-compliant.