### PR TITLE
Fix vendor search in KEVin API

### DIFF
--- a/schema/api.py
+++ b/schema/api.py
@@ -259,7 +259,11 @@ class AllKevVulnerabilitiesResource(BaseResource):
             filter_ransomware = sanitize_query(request.args.get("filter", ''))
             actor_query = sanitize_query(request.args.get("actor", ''))
 
-            query = {"$text": {"$search": search_query}} if search_query else {}
+            query = {}
+            if search_query:
+                search_term = search_query.strip()
+                # Only search in the vendorProject field
+                query["vendorProject"] = {"$regex": search_term, "$options": "i"}
             if filter_ransomware.lower() == 'ransomware':
                 query["knownRansomwareCampaignUse"] = "Known"
             if actor_query and actor_query.strip():  # Ensure actor_query is not empty or just whitespace

--- a/schema/api.py
+++ b/schema/api.py
@@ -11,8 +11,9 @@ from datetime import datetime, timedelta
 import math
 import os
 from schema.serializers import serialize_vulnerability, serialize_all_vulnerability, nvd_serializer, mitre_serializer, serialize_githubpocs
-from gevent import spawn, joinall
+from gevent import joinall
 from gevent.pool import Pool
+import re
 
 # Load env using python-dotenv
 from dotenv import load_dotenv
@@ -261,7 +262,8 @@ class AllKevVulnerabilitiesResource(BaseResource):
 
             query = {}
             if search_query:
-                search_term = search_query.strip()
+                # Escape special characters in the search term even if it's already sanitized.
+                search_term = re.escape(search_query.strip())
                 # Only search in the vendorProject field
                 query["vendorProject"] = {"$regex": search_term, "$options": "i"}
             if filter_ransomware.lower() == 'ransomware':


### PR DESCRIPTION
This PR fixes the vendor search functionality in the KEVin API by ensuring that search queries only target the vendorProject field using a case-insensitive regex. This allows users to search for vendor names such as 'Microsoft' or 'Apache' and receive correct results, even if a MongoDB text index is not available. The fix also preserves compatibility with other filters (ransomware, actor, etc).