### PR TITLE
Fix memory usage in filter and days

### DIFF
--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -77,6 +77,10 @@ class CacheManager:
         """Set data in the cache with a checksum for integrity."""
         try:
             if isinstance(value, Response):
+                # Streaming responses should not be cached; forcing them through
+                # get_data would buffer the entire payload and defeat streaming.
+                if getattr(value, "is_streamed", False):
+                    return
                 # Persist only essential headers to reduce cache footprint
                 content_type = value.headers.get("Content-Type")
                 minimal_headers = {"Content-Type": content_type} if content_type else {}


### PR DESCRIPTION
Shifted the recent-KEV endpoint to stream its Mongo cursor in small batches, closing the easy DoS vector where a large days window would chew through memory while assembling the full payload. Tightened AllKevVulnerabilitiesResource so clients can only sort on indexed fields (dateAdded, dueDate, cveID), blocking attacker-controlled sorts that forced Mongo into expensive collection scans, and left a manual test recipe to confirm the 400 response. Also taught the cache manager to skip streaming responses so we keep the new streaming defence instead of re-buffering it during cache writes.