### PR TITLE
[codex] Bump orjson to patched version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==2.1.5
-orjson==3.10.18
+orjson==3.11.8
 packaging==24.1
 pluggy==1.5.0
 pymongo==4.16.0


### PR DESCRIPTION
## Summary
- bump `orjson` from `3.10.18` to `3.11.8`
- address `CVE-2025-67221` / `GHSA-hx9q-6w63-j58v` reported against the previous pin
- keep the upgrade set intentionally minimal to avoid unrelated dependency churn

## Validation
- created a fresh Python 3.13 virtual environment and ran `pip install -r requirements.txt`
- ran `pip-audit -r requirements.txt` after the bump and confirmed `No known vulnerabilities found`

## Notes
- I did not broaden this sweep to other outdated packages because the goal here was the smallest viable safe upgrade set.
- `pytest -q` is not a reliable validation step in this environment because importing the app triggers live MongoDB and Redis initialization during test collection.