### PR TITLE
[codex] Bump click and Werkzeug patch releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ blinker==1.9.0
 Brotli @ git+https://github.com/google/brotli.git@v1.2.0#egg=Brotli
 certifi==2026.2.25
 charset-normalizer==3.4.7
-click==8.3.1
+click==8.3.2
 cramjam==2.9.0
 defusedxml==0.7.1
 dnspython==2.8.0
@@ -36,7 +36,7 @@ setuptools==78.1.1
 six==1.16.0
 terminaltables==3.1.10
 urllib3==2.6.3
-Werkzeug==3.1.7
+Werkzeug==3.1.8
 zope.event==6.1
 zope.interface==8.2
 zstandard==0.23.0


### PR DESCRIPTION
## What changed
- bumped `click` from `8.3.1` to `8.3.2`
- bumped `Werkzeug` from `3.1.7` to `3.1.8`

## Why
- this repository has several outdated pins, but this sweep intentionally keeps the upgrade set minimal
- `click` and `Werkzeug` are low-risk patch updates in the active runtime stack
- larger jumps such as `redis 6 -> 7`, `pytest 8 -> 9`, `gevent 25 -> 26`, and `aniso8601 9 -> 10` were left alone because they carry higher migration risk and were not required for a security fix

## Security
- checked the pinned PyPI packages against OSV; no known vulnerabilities were returned for the current pinned set
- as a result, this PR mitigates maintenance drift but does not claim a specific CVE fix

## Validation
- confirmed the current pins from `requirements.txt` before proposing changes
- ran a fresh venv dependency resolution for Python 3.12 using `pip install --dry-run --ignore-installed --python-version 3.12 --only-binary=:all: -r requirements.txt`
- the updated requirements resolved successfully for Python 3.12, which matches the project's `python:3.12-slim` Docker base image
- local test execution is blocked in this sandbox because only Python 3.9 is available and `pytest` is not installed, so a real Python 3.12 test run could not be executed here

## Risk
- expected breaking-change risk is low because both updates are patch-level
- no application code changes were required
