### PR TITLE
[codex] Bump click and Werkzeug patch releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ blinker==1.9.0
 Brotli @ git+https://github.com/google/brotli.git@v1.2.0#egg=Brotli
 certifi==2026.2.25
 charset-normalizer==3.4.7
-click==8.3.1
+click==8.3.2
 cramjam==2.9.0
 defusedxml==0.7.1
 dnspython==2.8.0
@@ -36,7 +36,7 @@ setuptools==78.1.1
 six==1.16.0
 terminaltables==3.1.10
 urllib3==2.6.3
-Werkzeug==3.1.7
+Werkzeug==3.1.8
 zope.event==6.1
 zope.interface==8.2
 zstandard==0.23.0


### PR DESCRIPTION
## What changed
- bumped `click` from `8.3.1` to `8.3.2`
- bumped `Werkzeug` from `3.1.7` to `3.1.8`

## Why
- this sweep keeps the upgrade set minimal and focused on low-risk patch releases
- `click` and `Werkzeug` both resolved and installed cleanly in a fresh Python 3.12 virtualenv
- higher-risk jumps were deferred: `redis 6.4.0 -> 7.4.0`, `pytest 8.3.4 -> 9.0.3`, `gevent 25.9.1 -> 26.4.0`, and `aniso8601 9.0.1 -> 10.0.1`

## Security
- checked the pinned dependency set for known vulnerabilities and found none
- this PR reduces maintenance drift but does not claim a specific CVE fix

## Validation
- confirmed current pinned versions from `requirements.txt` before proposing updates
- created a fresh Python 3.12.12 virtualenv and successfully installed the updated `requirements.txt`
- `pytest -q` still fails during test collection because importing `kevin.py` triggers a MongoDB connection attempt from `utils/database.py`
- no application code changes were required for these dependency bumps

## Risk
- expected breaking-change risk is low because both updates are patch-level releases
- deferred packages above may require separate migration work and should not be bundled into this PR
