### PR TITLE
chore: upgrade pytest for CVE-2025-71176

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ orjson==3.11.8
 packaging==24.1
 pluggy==1.5.0
 pymongo==4.16.0
-pytest==8.3.4
+pytest==9.0.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-snappy==0.7.3


### PR DESCRIPTION
## Summary
- update `pytest` from `8.3.4` to `9.0.3` in `requirements.txt`
- keep the upgrade set minimal because this was the only pinned package with a confirmed vulnerability
- preserve the rest of the dependency set unchanged to avoid unnecessary runtime churn

## Security
- mitigates `CVE-2025-71176` / `GHSA-6w46-j5rx-g56g` affecting `pytest 8.3.4`
- follow-up `pip-audit` reported no known vulnerabilities in the pinned requirements after this change

## Verification
- created a fresh Python `3.12.12` venv
- `pip install -r requirements.txt`
- `pip check`
- `pytest --version` -> `9.0.3`

## Risk
- `pytest` 9 is a major-version upgrade and can surface deprecations or collection behavior changes if additional tests/plugins are added later
- no repo-local pytest config or plugin usage was found in this codebase during the sweep