### PR TITLE
chore: refresh pinned Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ aniso8601==10.0.1
 blinker==1.9.0
 #Brotli==1.2.0
 Brotli @ git+https://github.com/google/brotli.git@v1.2.0#egg=Brotli
-certifi==2026.2.25
+certifi==2026.4.22
 charset-normalizer==3.4.7
-click==8.3.2
+click==8.3.3
 cramjam==2.11.0
 defusedxml==0.7.1
 dnspython==2.8.0
@@ -14,15 +14,15 @@ flask-cors==6.0.2
 flask-orjson==2.0.0
 Flask-RESTful==0.3.10
 gevent==26.4.0
-greenlet==3.4.0
+greenlet==3.5.0
 gunicorn==25.3.0
-idna==3.12
+idna==3.13
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
 orjson==3.11.8
-packaging==26.1
+packaging==26.2
 pluggy==1.6.0
 pymongo==4.17.0
 pytest==9.0.3
@@ -38,5 +38,5 @@ terminaltables==3.1.10
 urllib3==2.6.3
 Werkzeug==3.1.8
 zope.event==6.1
-zope.interface==8.3
+zope.interface==8.4
 zstandard==0.25.0


### PR DESCRIPTION
## Summary
- Updated pinned Python dependencies in `requirements.txt`:
  - `certifi` 2026.2.25 -> 2026.4.22
  - `click` 8.3.2 -> 8.3.3
  - `greenlet` 3.4.0 -> 3.5.0
  - `idna` 3.12 -> 3.13
  - `packaging` 26.1 -> 26.2
  - `zope.interface` 8.3 -> 8.4
- Checked open Dependabot PRs first; this includes the active Dependabot updates for `certifi`, `click`, `idna`, and `packaging`.
- No known vulnerabilities were reported before or after this sweep, so no security CVEs were mitigated by these updates.
- Breaking-change risk appears low: all changes are patch or small minor updates within existing compatibility ranges, and the pinned environment installs cleanly.

## Verification
- Created a fresh Python 3.12.12 venv and installed `requirements.txt` successfully
- `python -m pip check`
- `python -m pip_audit -r requirements.txt --cache-dir /tmp/kevin-pip-audit-cache-updated`
- `python -m pip list --outdated --format=json` returned `[]` after installing the updated pins

Note: full test execution was intentionally skipped because the app attempts to connect to MongoDB during broader test runs.
