### PR TITLE
Refresh pinned Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytest==9.0.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-snappy==0.7.3
-pytz==2026.1.post1
+pytz==2026.2
 redis==7.4.0
 requests==2.33.1
 setuptools==82.0.1
@@ -37,6 +37,6 @@ six==1.17.0
 terminaltables==3.1.10
 urllib3==2.6.3
 Werkzeug==3.1.8
-zope.event==6.1
+zope.event==6.2
 zope.interface==8.4
 zstandard==0.25.0


### PR DESCRIPTION
## Summary
- Update pytz from 2026.1.post1 to 2026.2
- Update zope.event from 6.1 to 6.2

## Security
- pip-audit reported no known vulnerabilities before or after these updates, so no CVEs were mitigated in this sweep.

## Compatibility
- No breaking-change risks identified for this minimal patch/minor dependency refresh.
- The old open Dependabot six PR is already satisfied by requirements.txt at six==1.17.0.

## Verification
- Fresh Python 3.12.12 venv install from requirements.txt succeeded
- python -m pip check
- python -m pip list --outdated --format=json returned []
- pip-audit -r requirements.txt reported no known vulnerabilities