### PR TITLE
Refresh pinned Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,13 +15,13 @@ flask-orjson==2.0.0
 Flask-RESTful==0.3.10
 gevent==26.4.0
 greenlet==3.5.0
-gunicorn==25.3.0
-idna==3.13
+gunicorn==26.0.0
+idna==3.14
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
-orjson==3.11.8
+orjson==3.11.9
 packaging==26.2
 pluggy==1.6.0
 pymongo==4.17.0
@@ -35,7 +35,7 @@ requests==2.33.1
 setuptools==82.0.1
 six==1.17.0
 terminaltables==3.1.10
-urllib3==2.6.3
+urllib3==2.7.0
 Werkzeug==3.1.8
 zope.event==6.2
 zope.interface==8.4


### PR DESCRIPTION
## Summary
- Updated `gunicorn` from 25.3.0 to 26.0.0
- Updated `idna` from 3.13 to 3.14
- Updated `orjson` from 3.11.8 to 3.11.9
- Updated `urllib3` from 2.6.3 to 2.7.0

## Security
- `idna` 3.14 rejects oversize inputs up front to close a bypass of the CVE-2024-3651 mitigation, tracked upstream as GHSA-65pc-fj4g-8rjx.
- `urllib3` 2.7.0 addresses high-severity decompression safeguard bypasses in specific streaming API cases, tracked upstream as GHSA-mf9v-mfxr-j63j.
- `gunicorn` 26.0.0 includes HTTP parser and request smuggling hardening.
- `pip-audit` reported no known vulnerabilities after the refresh.

## Breaking-change risk / migrations
- `gunicorn` 26.0.0 removes the eventlet worker. This repo uses the gevent worker in the Docker command and no eventlet usage was found, so no migration is required.
- No required migrations were identified for the `idna`, `orjson`, or `urllib3` bumps.

## Verification
- Fresh Python 3.12.12 venv install from `requirements.txt` succeeded.
- `python -m pip check` passed.
- `python -m pip list --outdated --format=json` returned `[]`.
- `python -m pip_audit -r requirements.txt --cache-dir /private/tmp/kevin-pip-audit-cache-2026-05-11-after` reported no known vulnerabilities.