### PR TITLE
[codex] Mitigate security scanner findings

### DIFF
--- a/schema/api.py
+++ b/schema/api.py
@@ -22,6 +22,7 @@ load_dotenv()
 # Fields clients are allowed to sort on for KEV listings. Keep in sync with
 # Mongo indexes so we never trigger an expensive collection scan.
 ALLOWED_KEV_SORT_FIELDS = {"dateAdded", "dueDate", "cveID"}
+MAX_PAGE = max(1, int(os.environ.get("MAX_PAGE", 1000)))
 
 # Configure the maximum number of concurrent greenlets
 # This helps prevent server overload from too many concurrent operations
@@ -51,6 +52,12 @@ def kill_unfinished_greenlets(greenlets):
                 greenlet.kill(block=False)
             except Exception:
                 pass
+
+def validate_page(page):
+    """Reject non-positive and unbounded pages before MongoDB skip() calls."""
+    if page < 1:
+        return None
+    return min(page, MAX_PAGE)
 
 class BaseResource(Resource):
     def handle_error(self, message, status=404):
@@ -311,6 +318,9 @@ class AllKevVulnerabilitiesResource(BaseResource):
                 per_page = max(1, min(100, int(request.args.get("per_page", 25))))
             except ValueError:
                 return self.handle_error("Invalid page or per_page parameter. Must be integers.", 400)
+            page = validate_page(page)
+            if page is None:
+                return self.handle_error("Invalid page parameter. Must be a positive integer.", 400)
 
             sort_input = request.args.get("sort", "dateAdded")
             sort_param = sanitize_query(sort_input)
@@ -485,6 +495,13 @@ class RecentVulnerabilitiesByDaysResource(BaseResource):
         days = request.args.get("days")
         page = request.args.get("page", default=1, type=int)  # Default to page 1 if not provided
         per_page = request.args.get("per_page", default=25, type=int)
+        if page is None:
+            return self.handle_error("Invalid page parameter. Must be an integer.", 400)
+        if per_page is None:
+            return self.handle_error("Invalid per_page parameter. Must be an integer.", 400)
+        page = validate_page(page)
+        if page is None:
+            return self.handle_error("Invalid page parameter. Must be a positive integer.", 400)
         if per_page > 100:
             return self.handle_error("The 'per_page' parameter cannot exceed 100.", 400)
         per_page = max(1, per_page)  # Ensure per_page is at least 1

--- a/static/viz.html
+++ b/static/viz.html
@@ -518,22 +518,50 @@
     <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
     <script>
         $(document).ready(function () {
+            function textValue(value, fallback = '') {
+                return value === null || value === undefined ? fallback : String(value);
+            }
+
+            function escapeHtml(value) {
+                return textValue(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            function textRenderer(data, type) {
+                return type === 'display' || type === 'filter' ? escapeHtml(data) : textValue(data);
+            }
+
+            function isHttpUrl(value) {
+                if (typeof value !== 'string') {
+                    return false;
+                }
+                try {
+                    const parsed = new URL(value);
+                    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+                } catch (error) {
+                    return false;
+                }
+            }
+
             $('#kevTable').DataTable({
                 serverSide: true,
                 processing: true,
                 ajax: function (data, callback, settings) {
                     const page = Math.ceil(data.start / data.length) + 1;
                     fetch(`/kev?page=${page}&per_page=${data.length}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            const formattedData = data.vulnerabilities.map(kev => ({
-                                cveId: kev.cveID,
-                                description: kev.shortDescription,
-                                publishedDate: new Date(kev.dateAdded).toLocaleDateString(),
-                                severity: kev.nvdData[0]?.baseSeverity || 'Unknown',
-                                link: `<a href="#" class="view-link" data-id="${kev.cveID}">View</a>`,
-                                githubPocs: kev.githubPocs
-                            }));
+	                        .then(response => response.json())
+	                        .then(data => {
+	                            const formattedData = data.vulnerabilities.map(kev => ({
+	                                cveId: textValue(kev.cveID),
+	                                description: textValue(kev.shortDescription),
+	                                publishedDate: new Date(kev.dateAdded).toLocaleDateString(),
+	                                severity: Array.isArray(kev.nvdData) ? kev.nvdData[0]?.baseSeverity || 'Unknown' : 'Unknown',
+	                                githubPocs: Array.isArray(kev.githubPocs) ? kev.githubPocs : []
+	                            }));
                             callback({
                                 draw: data.draw,
                                 recordsTotal: data.total_vulns,
@@ -542,20 +570,29 @@
                             });
                         })
                         .catch(error => console.error('Error fetching KEV data:', error));
-                },
-                columns: [
-                    { data: 'cveId' },
-                    { data: 'description', className: 'description' },
-                    { data: 'publishedDate' },
-                    { data: 'severity' },
-                    { data: 'link' },
-                    {
-                        data: 'githubPocs',
-                        render: function (data) {
-                            return data.length === 0
-                                ? '<span class="status-negative">No PoCs</span>'
-                                : '<span class="status-positive">Potential PoCs</span>';
-                        }
+	                },
+	                columns: [
+	                    { data: 'cveId', render: textRenderer },
+	                    { data: 'description', className: 'description', render: textRenderer },
+	                    { data: 'publishedDate', render: textRenderer },
+	                    { data: 'severity', render: textRenderer },
+	                    {
+	                        data: 'cveId',
+	                        orderable: false,
+	                        render: function (data, type) {
+	                            if (type !== 'display') {
+	                                return textValue(data);
+	                            }
+	                            return `<a href="#" class="view-link" data-id="${escapeHtml(data)}">View</a>`;
+	                        }
+	                    },
+	                    {
+	                        data: 'githubPocs',
+	                        render: function (data) {
+	                            return !Array.isArray(data) || data.length === 0
+	                                ? '<span class="status-negative">No PoCs</span>'
+	                                : '<span class="status-positive">Potential PoCs</span>';
+	                        }
                     }
                 ],
                 pageLength: 25,
@@ -564,56 +601,80 @@
                 searching: false
             });
 
-            $(document).on('click', '.view-link', function (e) {
-                e.preventDefault();
-                const cveId = $(this).data('id');
-                fetchVulnerabilityDetails(cveId);
-            });
+	            $(document).on('click', '.view-link', function (e) {
+	                e.preventDefault();
+	                const cveId = $(this).attr('data-id');
+	                fetchVulnerabilityDetails(cveId);
+	            });
 
-            function fetchVulnerabilityDetails(cveId) {
-                fetch(`/kev/${cveId}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        $('#kevModalLabel').text(`Vulnerability Details for ${data.cveID}`);
+	            function fetchVulnerabilityDetails(cveId) {
+	                fetch(`/kev/${encodeURIComponent(cveId)}`)
+	                    .then(response => response.json())
+	                    .then(data => {
+	                        $('#kevModalLabel').text(`Vulnerability Details for ${textValue(data.cveID, 'Unknown')}`);
 
-                        const threatActors = new Set();
-                        if (data.openThreatData && data.openThreatData.length > 0) {
-                            const threatData = data.openThreatData[0];
-                            threatData.adversaries.forEach(actor => threatActors.add(actor));
-                            threatData.communityAdversaries.forEach(actor => threatActors.add(actor));
-                        }
+	                        const threatActors = new Set();
+	                        if (Array.isArray(data.openThreatData) && data.openThreatData.length > 0) {
+	                            const threatData = data.openThreatData[0];
+	                            if (Array.isArray(threatData.adversaries)) {
+	                                threatData.adversaries.forEach(actor => threatActors.add(textValue(actor)));
+	                            }
+	                            if (Array.isArray(threatData.communityAdversaries)) {
+	                                threatData.communityAdversaries.forEach(actor => threatActors.add(textValue(actor)));
+	                            }
+	                        }
 
-                        const threatActorsHtml = threatActors.size > 0
-                            ? `<ul>${Array.from(threatActors).map(actor => `<li>${actor}</li>`).join('')}</ul>`
-                            : '<p>No Threat Actors available.</p>';
+	                        const severity = Array.isArray(data.nvdData) ? data.nvdData[0]?.baseSeverity || 'Unknown' : 'Unknown';
+	                        const $card = $('<div>', { class: 'card mb-3' });
+	                        const $body = $('<div>', { class: 'card-body' }).appendTo($card);
+	                        $('<h5>', { class: 'card-title' }).text(textValue(data.vulnerabilityName, 'Unknown')).appendTo($body);
+	                        $('<p>', { class: 'card-text' }).text(textValue(data.shortDescription, 'No description available.')).appendTo($body);
 
-                        const githubPocsHtml = data.githubPocs.length > 0
-                            ? `<ul class="list-group">${data.githubPocs.map(poc => `<li class="list-group-item"><a href="${poc}" target="_blank" rel="noopener noreferrer">${poc}</a></li>`).join('')}</ul>`
-                            : '<p>No PoCs available.</p>';
+	                        [
+	                            ['Published Date', data.dateAdded || 'Unknown'],
+	                            ['Severity', severity],
+	                            ['Required Action', data.requiredAction || 'Unknown']
+	                        ].forEach(([label, value]) => {
+	                            $('<p>')
+	                                .append($('<strong>').text(`${label}: `))
+	                                .append(document.createTextNode(textValue(value)))
+	                                .appendTo($body);
+	                        });
 
-                        $('#modalContent').html(`
-                        <div class="card mb-3">
-                            <div class="card-body">
-                                <h5 class="card-title">${data.vulnerabilityName}</h5>
-                                <p class="card-text">${data.shortDescription}</p>
-                                <p><strong>Published Date:</strong> ${data.dateAdded}</p>
-                                <p><strong>Severity:</strong> ${data.nvdData[0]?.baseSeverity || 'Unknown'}</p>
-                                <p><strong>Required Action:</strong> ${data.requiredAction}</p>
-                                <div class="scrollable">
-                                    <strong>Threat Actors:</strong>
-                                    <div class="scrollable">
-                                        ${threatActorsHtml}
-                                    </div>
-                                </div>
-                                <div class="scrollable">
-                                    <strong>GitHub PoCs:</strong>
-                                    ${githubPocsHtml}
-                                </div>
-                            </div>
-                        </div>
-                    `);
-                        $('#kevModal').modal('show');
-                    })
+	                        const $threatSection = $('<div>', { class: 'scrollable' })
+	                            .append($('<strong>').text('Threat Actors:'))
+	                            .appendTo($body);
+	                        const $threatBody = $('<div>', { class: 'scrollable' }).appendTo($threatSection);
+	                        if (threatActors.size > 0) {
+	                            const $list = $('<ul>').appendTo($threatBody);
+	                            Array.from(threatActors).forEach(actor => $('<li>').text(actor).appendTo($list));
+	                        } else {
+	                            $('<p>').text('No Threat Actors available.').appendTo($threatBody);
+	                        }
+
+	                        const $pocSection = $('<div>', { class: 'scrollable' })
+	                            .append($('<strong>').text('GitHub PoCs:'))
+	                            .appendTo($body);
+	                        const pocs = Array.isArray(data.githubPocs) ? data.githubPocs.filter(isHttpUrl) : [];
+	                        if (pocs.length > 0) {
+	                            const $list = $('<ul>', { class: 'list-group' }).appendTo($pocSection);
+	                            pocs.forEach(poc => {
+	                                const safeUrl = new URL(poc).href;
+	                                $('<li>', { class: 'list-group-item' })
+	                                    .append($('<a>', {
+	                                        href: safeUrl,
+	                                        target: '_blank',
+	                                        rel: 'noopener noreferrer'
+	                                    }).text(poc))
+	                                    .appendTo($list);
+	                            });
+	                        } else {
+	                            $('<p>').text('No PoCs available.').appendTo($pocSection);
+	                        }
+
+	                        $('#modalContent').empty().append($card);
+	                        $('#kevModal').modal('show');
+	                    })
                     .catch(error => console.error('Error fetching vulnerability details:', error));
             }
         });

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -27,7 +27,8 @@ def test_sanitize_query():
     assert sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
     assert sanitize_query("1; DROP TABLE users") is None
     assert sanitize_query("admin' --") == "admin --"
-    assert sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom target_blankLinka"
+    link_payload = "<a href='http://example.com' target='_blank'>Link</a>"
+    assert sanitize_query(link_payload) == "a hrefhttpexamplecom target_blankLinka"
 
     # Test for double URL encoded values
     assert sanitize_query("%253Cscript%253E") == "script"
@@ -55,7 +56,8 @@ def test_api_sanitize_query():
     assert api_sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
     assert api_sanitize_query("1; DROP TABLE users") is None
     assert api_sanitize_query("admin' --") == "admin --"
-    assert api_sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom target_blankLinka"
+    link_payload = "<a href='http://example.com' target='_blank'>Link</a>"
+    assert api_sanitize_query(link_payload) == "a hrefhttpexamplecom target_blankLinka"
 
     # Test for double URL encoded values
     assert api_sanitize_query("%253Cscript%253E") == "script"

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -25,9 +25,9 @@ def test_sanitize_query():
 
     # Additional tests for malicious input
     assert sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
-    assert sanitize_query("1; DROP TABLE users") == "1 DROP TABLE users"
+    assert sanitize_query("1; DROP TABLE users") is None
     assert sanitize_query("admin' --") == "admin --"
-    assert sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom targetblankLinka"
+    assert sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom target_blankLinka"
 
     # Test for double URL encoded values
     assert sanitize_query("%253Cscript%253E") == "script"
@@ -53,11 +53,10 @@ def test_api_sanitize_query():
 
     # Additional tests for malicious input
     assert api_sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
-    assert api_sanitize_query("1; DROP TABLE users") == "1 DROP TABLE users"
+    assert api_sanitize_query("1; DROP TABLE users") is None
     assert api_sanitize_query("admin' --") == "admin --"
     assert api_sanitize_query("<a href='http://example.com' target='_blank'>Link</a>") == "a hrefhttpexamplecom target_blankLinka"
 
     # Test for double URL encoded values
     assert api_sanitize_query("%253Cscript%253E") == "script"
     assert api_sanitize_query("%2520") == ""
-    

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
+"""Tests for shared query sanitization behavior."""
 
-import pytest
 from kevin import sanitize_query
 from schema.api import sanitize_query as api_sanitize_query
 
 def test_sanitize_query():
+    """Sanitize common inputs and reject suspicious SQL-like payloads."""
     assert sanitize_query("abc123") == "abc123"
     assert sanitize_query("abc 123") == "abc 123"
     assert sanitize_query("abc-123") == "abc-123"
     assert sanitize_query("abc@123") == "abc123"
-    assert sanitize_query(None) == None
+    assert sanitize_query(None) is None
     assert sanitize_query(123) == "123"
     assert sanitize_query("CVE-1234-123456") == "CVE-1234-123456"
     assert sanitize_query("cve-1234-123456") == "CVE-1234-123456"
-    
 
     # Test for potential MongoDB injection attacks
     assert sanitize_query("{$ne: null}") == "ne null"
@@ -35,11 +35,12 @@ def test_sanitize_query():
     assert sanitize_query("%2520") == ""
 
 def test_api_sanitize_query():
+    """Apply the same sanitizer expectations through the API module export."""
     assert api_sanitize_query("abc123") == "abc123"
     assert api_sanitize_query("abc 123") == "abc 123"
     assert api_sanitize_query("abc-123") == "abc-123"
     assert api_sanitize_query("abc@123") == "abc123"
-    assert api_sanitize_query(None) == None
+    assert api_sanitize_query(None) is None
     assert api_sanitize_query(123) == "123"
     assert api_sanitize_query("CVE-1234-123456") == "CVE-1234-123456"
     assert api_sanitize_query("cve-1234-123456") == "CVE-1234-123456"

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import importlib
 from pathlib import Path
 import sys
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as element_tree
 
 from utils.rss_feed import create_rss_feed
 
@@ -31,7 +31,7 @@ def test_rss_feed_escapes_description_html_fields():
         ],
     }
 
-    root = ET.fromstring(create_rss_feed([entry]))
+    root = element_tree.fromstring(create_rss_feed([entry]))
     description = root.find("channel/item/description").text
 
     assert "<img" not in description

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -1,8 +1,12 @@
+"""Regression tests for vulnerability mitigations."""
+
 from datetime import datetime
-from pathlib import Path
 import importlib
+from pathlib import Path
 import sys
 import xml.etree.ElementTree as ET
+
+from utils.rss_feed import create_rss_feed
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -11,8 +15,7 @@ if str(ROOT) not in sys.path:
 
 
 def test_rss_feed_escapes_description_html_fields():
-    from utils.rss_feed import create_rss_feed
-
+    """RSS descriptions escape attacker-controlled HTML fragments."""
     entry = {
         "cveID": "CVE-2026-0001",
         "vulnerabilityName": "Name",
@@ -39,6 +42,7 @@ def test_rss_feed_escapes_description_html_fields():
 
 
 def test_cache_keys_include_function_identity_and_path(monkeypatch):
+    """Redis cache keys separate route and function identity."""
     monkeypatch.setenv("REDIS_IP", "localhost")
     cache_manager = importlib.import_module("utils.cache_manager")
 
@@ -46,14 +50,12 @@ def test_cache_keys_include_function_identity_and_path(monkeypatch):
     nvd_key = cache_manager.build_cache_key(
         "cache_",
         "schema.api.cveNVDResource.get",
-        method_args=cve,
-        path="/vuln/CVE-2026-0001/nvd",
+        {"method_args": cve, "path": "/vuln/CVE-2026-0001/nvd"},
     )
     mitre_key = cache_manager.build_cache_key(
         "cache_",
         "schema.api.cveMitreResource.get",
-        method_args=cve,
-        path="/vuln/CVE-2026-0001/mitre",
+        {"method_args": cve, "path": "/vuln/CVE-2026-0001/mitre"},
     )
     assert nvd_key != mitre_key
 
@@ -61,19 +63,18 @@ def test_cache_keys_include_function_identity_and_path(monkeypatch):
     published_key = cache_manager.build_cache_key(
         "recent_days_vulnerabilities",
         "schema.api.RecentVulnerabilitiesByDaysResource.get",
-        query_items=query_items,
-        path="/vuln/published",
+        {"query_items": query_items, "path": "/vuln/published"},
     )
     modified_key = cache_manager.build_cache_key(
         "recent_days_vulnerabilities",
         "schema.api.RecentVulnerabilitiesByDaysResource.get",
-        query_items=query_items,
-        path="/vuln/modified",
+        {"query_items": query_items, "path": "/vuln/modified"},
     )
     assert published_key != modified_key
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():
+    """Visualization code avoids unsafe HTML sinks for untrusted API fields."""
     source = (ROOT / "static" / "viz.html").read_text()
 
     assert "function escapeHtml(value)" in source
@@ -85,6 +86,7 @@ def test_viz_uses_text_safe_rendering_for_untrusted_api_data():
 
 
 def test_public_pagination_paths_validate_page_before_skip():
+    """Public pagination paths validate page values before MongoDB skip calls."""
     source = (ROOT / "schema" / "api.py").read_text()
 
     assert "MAX_PAGE" in source

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+from pathlib import Path
+import importlib
+import sys
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_rss_feed_escapes_description_html_fields():
+    from utils.rss_feed import create_rss_feed
+
+    entry = {
+        "cveID": "CVE-2026-0001",
+        "vulnerabilityName": "Name",
+        "dateAdded": datetime(2026, 1, 1),
+        "shortDescription": "<b>escaped</b>",
+        "knownRansomwareCampaignUse": "<img src=x onerror=alert(1)>",
+        "githubPocs": ["<img src=x onerror=alert(2)>"],
+        "openThreatData": [
+            {
+                "adversaries": ["<img src=x onerror=alert(3)>"],
+                "affectedIndustries": ["<img src=x onerror=alert(4)>"],
+            }
+        ],
+    }
+
+    root = ET.fromstring(create_rss_feed([entry]))
+    description = root.find("channel/item/description").text
+
+    assert "<img" not in description
+    assert "&lt;img src=x onerror=alert(1)&gt;" in description
+    assert "&lt;img src=x onerror=alert(2)&gt;" in description
+    assert "&lt;img src=x onerror=alert(3)&gt;" in description
+    assert "&lt;img src=x onerror=alert(4)&gt;" in description
+
+
+def test_cache_keys_include_function_identity_and_path(monkeypatch):
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_manager = importlib.import_module("utils.cache_manager")
+
+    cve = ("CVE-2026-0001",)
+    nvd_key = cache_manager.build_cache_key(
+        "cache_",
+        "schema.api.cveNVDResource.get",
+        method_args=cve,
+        path="/vuln/CVE-2026-0001/nvd",
+    )
+    mitre_key = cache_manager.build_cache_key(
+        "cache_",
+        "schema.api.cveMitreResource.get",
+        method_args=cve,
+        path="/vuln/CVE-2026-0001/mitre",
+    )
+    assert nvd_key != mitre_key
+
+    query_items = [("days", ["7"]), ("page", ["1"]), ("per_page", ["25"])]
+    published_key = cache_manager.build_cache_key(
+        "recent_days_vulnerabilities",
+        "schema.api.RecentVulnerabilitiesByDaysResource.get",
+        query_items=query_items,
+        path="/vuln/published",
+    )
+    modified_key = cache_manager.build_cache_key(
+        "recent_days_vulnerabilities",
+        "schema.api.RecentVulnerabilitiesByDaysResource.get",
+        query_items=query_items,
+        path="/vuln/modified",
+    )
+    assert published_key != modified_key
+
+
+def test_viz_uses_text_safe_rendering_for_untrusted_api_data():
+    source = (ROOT / "static" / "viz.html").read_text()
+
+    assert "function escapeHtml(value)" in source
+    assert "{ data: 'cveId', render: textRenderer }" in source
+    assert "{ data: 'description', className: 'description', render: textRenderer }" in source
+    assert "$('#modalContent').html" not in source
+    assert "$('#modalContent').empty().append($card)" in source
+    assert "data.githubPocs.filter(isHttpUrl)" in source
+
+
+def test_public_pagination_paths_validate_page_before_skip():
+    source = (ROOT / "schema" / "api.py").read_text()
+
+    assert "MAX_PAGE" in source
+    assert source.count("page = validate_page(page)") >= 2
+    assert "skip((page - 1) * per_page)" in source

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -33,15 +33,14 @@ def normalize_cache_key_prefix(prefix_value):
 
     return prefix_value
 
-def build_cache_key(
-    prefix_value,
-    func_identity,
-    method_args=None,
-    kwargs=None,
-    query_items=None,
-    path=None,
-):
+def build_cache_key(prefix_value, func_identity, cache_context=None):
     """Build a route-aware cache key for cached Flask handlers."""
+    cache_context = cache_context or {}
+    method_args = cache_context.get("method_args")
+    kwargs = cache_context.get("kwargs")
+    query_items = cache_context.get("query_items")
+    path = cache_context.get("path")
+
     key_parts = [
         normalize_cache_key_prefix(prefix_value),
         f"func_{hash_cache_component(func_identity)}",
@@ -58,7 +57,10 @@ def build_cache_key(
 
     if kwargs:
         kwargs_hash = hashlib.sha256(
-            orjson.dumps(make_orjson_safe(dict(sorted(kwargs.items()))), option=orjson.OPT_SORT_KEYS)
+            orjson.dumps(
+                make_orjson_safe(dict(sorted(kwargs.items()))),
+                option=orjson.OPT_SORT_KEYS,
+            )
         ).hexdigest()
         key_parts.append(f"kwargs_{kwargs_hash}")
 
@@ -175,13 +177,16 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             if query_string and has_request_context():
                 query_items = list(request.args.lists())
 
+            cache_context = {
+                "method_args": method_args,
+                "kwargs": kwargs,
+                "query_items": query_items,
+                "path": path,
+            }
             cache_key = build_cache_key(
                 prefix_value,
                 f"{func.__module__}.{func.__qualname__}",
-                method_args=method_args,
-                kwargs=kwargs,
-                query_items=query_items,
-                path=path,
+                cache_context,
             )
 
             # Debug: print cache key

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -1,3 +1,5 @@
+"""Redis cache helpers for KEVin API responses."""
+
 import functools
 import hashlib
 from flask import Response, has_request_context, request
@@ -162,6 +164,7 @@ class CacheManager:
 cache_manager = CacheManager(redis_client)
 
 def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
+    """Cache Flask handler responses using route-aware Redis cache keys."""
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -1,6 +1,6 @@
 import functools
 import hashlib
-from flask import Response
+from flask import Response, has_request_context, request
 from utils.cache_config import redis_client
 import re
 import orjson
@@ -16,6 +16,58 @@ def sanitize_cache_key(key):
     if not SAFE_KEY_RE.match(key):
         raise ValueError(f"Unsafe cache key: {key}")
     return key
+
+def hash_cache_component(value):
+    """Hash arbitrary cache-key material into a safe fixed-width component."""
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+def normalize_cache_key_prefix(prefix_value):
+    """Return a safe cache-key prefix, hashing caller values with unsafe characters."""
+    if prefix_value is None:
+        prefix_value = "cache"
+    else:
+        prefix_value = str(prefix_value)
+
+    if not SAFE_KEY_RE.match(prefix_value):
+        prefix_value = hash_cache_component(prefix_value)
+
+    return prefix_value
+
+def build_cache_key(
+    prefix_value,
+    func_identity,
+    method_args=None,
+    kwargs=None,
+    query_items=None,
+    path=None,
+):
+    """Build a route-aware cache key for cached Flask handlers."""
+    key_parts = [
+        normalize_cache_key_prefix(prefix_value),
+        f"func_{hash_cache_component(func_identity)}",
+    ]
+
+    if path:
+        key_parts.append(f"path_{hash_cache_component(path)}")
+
+    if method_args:
+        args_hash = hashlib.sha256(
+            orjson.dumps(make_orjson_safe(method_args), option=orjson.OPT_SORT_KEYS)
+        ).hexdigest()
+        key_parts.append(f"args_{args_hash}")
+
+    if kwargs:
+        kwargs_hash = hashlib.sha256(
+            orjson.dumps(make_orjson_safe(dict(sorted(kwargs.items()))), option=orjson.OPT_SORT_KEYS)
+        ).hexdigest()
+        key_parts.append(f"kwargs_{kwargs_hash}")
+
+    if query_items is not None:
+        query_params = str(sorted(query_items))
+        query_hash = hashlib.sha256(query_params.encode('utf-8')).hexdigest()
+        key_parts.append(f"query_{query_hash}")
+
+    return sanitize_cache_key("_".join(key_parts))
 
 def make_orjson_safe(obj):
     """
@@ -118,37 +170,19 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             if callable(prefix_value):
                 prefix_value = prefix_value(*args, **kwargs)
 
-            if prefix_value is None:
-                prefix_value = "cache"
-            else:
-                prefix_value = str(prefix_value)
+            path = request.path if has_request_context() else None
+            query_items = None
+            if query_string and has_request_context():
+                query_items = list(request.args.lists())
 
-            if not SAFE_KEY_RE.match(prefix_value):
-                prefix_value = hashlib.sha256(prefix_value.encode('utf-8')).hexdigest()
-
-            key_parts = [prefix_value, func.__name__]
-            if method_args:
-                args_hash = hashlib.sha256(
-                    orjson.dumps(make_orjson_safe(method_args), option=orjson.OPT_SORT_KEYS)
-                ).hexdigest()
-                key_parts.append(f"args_{args_hash}")
-
-            if kwargs:
-                kwargs_hash = hashlib.sha256(
-                    orjson.dumps(make_orjson_safe(dict(sorted(kwargs.items()))), option=orjson.OPT_SORT_KEYS)
-                ).hexdigest()
-                key_parts.append(f"kwargs_{kwargs_hash}")
-
-            cache_key = "_".join(key_parts)
-
-            if query_string:
-                from flask import request
-                query_params = str(sorted(request.args.items()))
-                query_hash = hashlib.sha256(query_params.encode('utf-8')).hexdigest()
-                cache_key += f"_query_{query_hash}"
-
-            # Sanitize the generated cache key
-            cache_key = sanitize_cache_key(cache_key)
+            cache_key = build_cache_key(
+                prefix_value,
+                f"{func.__module__}.{func.__qualname__}",
+                method_args=method_args,
+                kwargs=kwargs,
+                query_items=query_items,
+                path=path,
+            )
 
             # Debug: print cache key
             # print(f"[kev_cache] Cache key: {cache_key}")

--- a/utils/rss_feed.py
+++ b/utils/rss_feed.py
@@ -2,6 +2,12 @@ import html
 from defusedxml import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 
+def escape_feed_html(value, default=""):
+    """Escape values before interpolating them into RSS description HTML."""
+    if value is None:
+        value = default
+    return html.escape(str(value), quote=True)
+
 def create_rss_feed(recent_entries):
     # Create the root element for the RSS feed
     rss = Element("rss", version="2.0")
@@ -36,11 +42,17 @@ def create_rss_feed(recent_entries):
         guid.set("isPermaLink", "true")
 
         # Add description with additional information
+        safe_cve_id = escape_feed_html(entry.get('cveID'), 'No CVE ID')
+        safe_description = escape_feed_html(entry.get('shortDescription'), 'No Description')
+        safe_ransomware_use = escape_feed_html(
+            entry.get('knownRansomwareCampaignUse'),
+            'No Known Ransomware Usage'
+        )
         description_html = f"""
-        <p><strong>CVE:</strong> {html.escape(entry.get('cveID', 'No CVE ID'))}</p>
-        <p><strong>Description:</strong> {html.escape(entry.get('shortDescription', 'No Description'))}</p>
+        <p><strong>CVE:</strong> {safe_cve_id}</p>
+        <p><strong>Description:</strong> {safe_description}</p>
         <ul>
-            <li><strong>Known Ransomware Usage:</strong> {entry.get('knownRansomwareCampaignUse', 'No Known Ransomware Usage')}</li>
+            <li><strong>Known Ransomware Usage:</strong> {safe_ransomware_use}</li>
             <li><strong>GitHub POCs:</strong>
                 <ul>
         """
@@ -49,7 +61,7 @@ def create_rss_feed(recent_entries):
         github_pocs = entry.get("githubPocs", [])
         if isinstance(github_pocs, list) and github_pocs:
             for poc in github_pocs:
-                description_html += f"<li>{poc}</li>"
+                description_html += f"<li>{escape_feed_html(poc)}</li>"
         else:
             description_html += "<li>No GitHub POCs</li>"
 
@@ -60,11 +72,17 @@ def create_rss_feed(recent_entries):
             adversaries = []
             affected_industries = []
             for data in open_threat_data:
+                if not isinstance(data, dict):
+                    continue
                 adversaries.extend(data.get("adversaries", []))
                 affected_industries.extend(data.get("affectedIndustries", []))
             
-            adversaries_str = ", ".join(set(adversaries)) if adversaries else "No Adversaries"
-            affected_industries_str = ", ".join(set(affected_industries)) if affected_industries else "No Affected Industries"
+            adversaries_str = ", ".join(
+                sorted({escape_feed_html(adversary) for adversary in adversaries})
+            ) if adversaries else "No Adversaries"
+            affected_industries_str = ", ".join(
+                sorted({escape_feed_html(industry) for industry in affected_industries})
+            ) if affected_industries else "No Affected Industries"
             open_threat_data_html = f"""
             <ul>
                 <li><strong>Adversaries:</strong> {adversaries_str}</li>


### PR DESCRIPTION
## Overview

This PR mitigates the reportable findings discovered by the security scanner. It keeps the generated scan and fix artifacts out of the repository and limits the code changes to the affected API, cache, RSS, visualization, and regression-test paths.

## Vulnerabilities and mitigations

### DOM XSS in the KEV table

The KEV visualization table rendered API-provided vulnerability fields directly through DataTables. A crafted CVE ID, description, date, or severity value could be interpreted as HTML in the browser.

The table now routes display and filter values through explicit text rendering and HTML escaping. The `View` action stores an escaped data attribute instead of reusing untrusted API HTML.

### DOM XSS in the vulnerability detail modal

The detail modal previously interpolated vulnerability fields, threat actors, and PoC links into an HTML string and inserted it with `.html(...)`. Any attacker-controlled value that reached those fields could execute in the modal context.

The modal now builds DOM nodes with jQuery and text nodes, uses `.text(...)` for untrusted values, URL-encodes CVE IDs before detail fetches, and only renders absolute `http:` or `https:` PoC links.

### Unbounded KEV listing pagination

The KEV listing endpoint accepted an arbitrary `page` value and used it to compute a MongoDB `skip` offset. Very large page values could force expensive skip work.

The API now validates page values before the skip path. Non-positive pages are rejected, and excessive pages are capped by `MAX_PAGE`, which defaults to `1000` and can be configured by environment.

### Unbounded recent vulnerability pagination

The recent published/modified vulnerability endpoints had the same unbounded `page` input before their MongoDB skip path.

Those endpoints now reject invalid/non-positive page values and cap large pages before querying MongoDB.

### Cache-key collision between NVD and MITRE detail routes

The Redis cache key did not include enough route identity for detail routes, so different endpoints for the same CVE could derive the same key shape.

Cache keys now include hashed function identity, request path, method arguments, keyword arguments, and optional query material while preserving the existing safe-key constraints.

### Cache-key collision between published and modified recent endpoints

The recent endpoint cache key separated query strings but not route paths, allowing `/published` and `/modified` requests with the same query to collide.

The cache decorator now includes the request path in route-aware keys and preserves duplicate query parameters through `request.args.lists()`.

### RSS description HTML injection

The RSS description assembled an HTML fragment with several unescaped fields, including ransomware usage, GitHub PoCs, adversaries, and affected industries.

RSS description values are now escaped before interpolation, including list values and nested threat-intel data. Non-dict threat data entries are ignored defensively.

## Validation

- `pytest -q tests` passed with `6 passed, 1 warning`.
- `pytest -q tests/security_regression_test.py` passed with `4 passed`.
- Python compile checks passed for the changed Python files.
- JavaScript syntax check passed for the changed visualization block.
- Mitigation validation harness passed for DOM XSS, pagination, cache-key separation, and RSS escaping controls.
- RSS injection replay now emits attacker markup as escaped text.
- Cache collision replay now produces distinct keys for the affected route pairs.
- `git diff --check` passed.

## Final synopsis

This PR closes the scanner findings by moving untrusted browser output to text-safe rendering, bounding public pagination before MongoDB skip operations, making Redis cache keys route-aware, and escaping RSS HTML fragments. It also adds focused regression coverage and updates stale sanitizer expectations so the test suite reflects the stricter existing sanitizer behavior.
