### PR TITLE
Group pip Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 1
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Group all pip version updates into one Dependabot PR
- Align Dependabot with the Monday dependency-sweep cadence
- Limit normal pip version-update PR noise to one open PR at a time

## Validation
- Parsed `.github/dependabot.yml` with Ruby YAML
- Checked the current open GitHub PR list and confirmed existing Dependabot PRs are already satisfied by `requirements.txt`
