### PR TITLE
chore: refresh pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ aniso8601==10.0.1
 blinker==1.9.0
 #Brotli==1.2.0
 Brotli @ git+https://github.com/google/brotli.git@v1.2.0#egg=Brotli
-certifi==2026.4.22
+certifi==2026.5.20
 charset-normalizer==3.4.7
-click==8.4.0
+click==8.4.1
 cramjam==2.11.0
 defusedxml==0.7.1
 dnspython==2.8.0
@@ -13,10 +13,10 @@ Flask-Compress==1.24
 flask-cors==6.0.2
 flask-orjson==2.0.0
 Flask-RESTful==0.3.10
-gevent==26.4.0
-greenlet==3.5.0
+gevent==26.5.0
+greenlet==3.5.1
 gunicorn==26.0.0
-idna==3.15
+idna==3.16
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6


### PR DESCRIPTION
## Summary
- Updated certifi from 2026.4.22 to 2026.5.20.
- Updated click from 8.4.0 to 8.4.1.
- Updated gevent from 26.4.0 to 26.5.0.
- Updated greenlet from 3.5.0 to 3.5.1.
- Updated idna from 3.15 to 3.16.

## Security
- `pip-audit -r requirements.txt` reported no known vulnerabilities before or after this sweep, so no CVE mitigation is claimed here.

## Breaking-change risk and migrations
- No required migrations identified.
- `gevent` is used directly and as the Gunicorn worker class, so that is the main runtime-sensitive update in this set; the fresh install, dependency check, outdated scan, audit, and import compilation all passed.
- No Click command definitions were found in the repo, so the Click patch update appears low risk.

## Verification
- `PYENV_VERSION=3.12.12 python -m venv /tmp/kevin-dependency-sweep-2026-05-25-after`
- `python -m pip install -r requirements.txt`
- `python -m pip check`
- `python -m pip list --outdated --format=json` returned `[]`.
- `python -m pip_audit -r requirements.txt --cache-dir /tmp/kevin-pip-audit-cache-2026-05-25-after` reported no known vulnerabilities.
- `python -m py_compile kevin.py nvd_processor.py update.py schema/api.py`
