### PR TITLE
Refresh pinned Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Flask-RESTful==0.3.10
 gevent==26.5.0
 greenlet==3.5.1
 gunicorn==26.0.0
-idna==3.16
+idna==3.17
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
@@ -38,5 +38,5 @@ terminaltables==3.1.10
 urllib3==2.7.0
 Werkzeug==3.1.8
 zope.event==6.2
-zope.interface==8.4
+zope.interface==8.5
 zstandard==0.25.0


### PR DESCRIPTION
## Summary
- Update `idna` from `3.16` to `3.17`.
- Update `zope.interface` from `8.4` to `8.5`.
- Leave `redis` at `7.4.0` because `8.0.0` is a major release with breaking-change risk in protocol/default connection behavior and this repo uses Redis directly for caching.

## Security
- `pip-audit -r requirements.txt` reports no known vulnerabilities before or after this sweep, so no CVEs were mitigated by these updates.
- `idna` 3.17 adds a public-entrypoint input length cap that hardens pathological input handling.

## Breaking-change risk / migrations
- No required migrations identified for `idna` 3.17 or `zope.interface` 8.5 on Python 3.12.
- `redis` 8.0.0 remains intentionally deferred for a separate compatibility pass.

## Verification
- Fresh Python 3.12.12 venv install from `requirements.txt` succeeded.
- `python -m pip check` passed.
- `python -m pip list --outdated --format=json` now reports only `redis==7.4.0 -> 8.0.0`, intentionally deferred.
- `python -m pip_audit -r requirements.txt --cache-dir /tmp/kevin-pip-audit-cache-2026-06-01-after` reported no known vulnerabilities.
- `python -m py_compile kevin.py nvd_processor.py update.py schema/api.py` passed.