### PR TITLE
[codex] Refresh pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ defusedxml==0.7.1
 dnspython==2.8.0
 Flask==3.1.3
 Flask-Compress==1.24
-flask-cors==6.0.2
+flask-cors==6.0.4
 flask-orjson==2.0.0
 Flask-RESTful==0.3.10
 gevent==26.5.0
 greenlet==3.5.1
 gunicorn==26.0.0
-idna==3.17
+idna==3.18
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6


### PR DESCRIPTION
## Summary
- Update `flask-cors` from `6.0.2` to `6.0.4`.
- Update `idna` from `3.17` to `3.18`.
- Leave `redis` pinned at `7.4.0`; `8.0.0` is a major release with connection, retry, and protocol-default behavior changes that should be handled separately.

## Security
- `pip-audit -r requirements.txt` reported no known vulnerabilities before or after this sweep, so no CVEs were mitigated by these updates.
- `flask-cors` 6.0.3 includes upstream CI/CD release workflow hardening, but this is upstream project hardening rather than an application dependency vulnerability fix.

## Breaking-change risk / migrations
- No required migrations identified for `flask-cors 6.0.4` or `idna 3.18`.
- `redis 8.0.0` remains deferred because KEVin directly uses Redis-backed caching and the major release changes runtime defaults.

## Verification
- Fresh Python `3.12.12` venv install from `requirements.txt` succeeded.
- `pip check` passed.
- `pip list --outdated --format=json` now reports only `redis 7.4.0 -> 8.0.0`.
- `pip-audit -r requirements.txt --cache-dir /tmp/kevin-pip-audit-cache-2026-06-08-after` reported no known vulnerabilities.
- `python -m py_compile kevin.py nvd_processor.py update.py schema/api.py` passed.