### PR TITLE
[codex] Refresh safe Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ defusedxml==0.7.1
 dnspython==2.8.0
 Flask==3.1.3
 Flask-Compress==1.24
-flask-cors==6.0.4
+flask-cors==6.0.5
 flask-orjson==2.0.0
 Flask-RESTful==0.3.10
 gevent==26.5.0
@@ -25,7 +25,7 @@ orjson==3.11.9
 packaging==26.2
 pluggy==1.6.0
 pymongo==4.17.0
-pytest==9.0.3
+pytest==9.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-snappy==0.7.3


### PR DESCRIPTION
## Summary

- Update `flask-cors` from `6.0.4` to `6.0.5`.
- Update `pytest` from `9.0.3` to `9.1.0`.
- Keep `redis` pinned at `7.4.0` because `8.0.0` is a major release with runtime-sensitive connection, retry, timeout, and protocol-default changes.

## Security

`pip-audit` reported no known vulnerabilities before or after this sweep, so this PR does not claim any CVE mitigation. The `flask-cors` update does move off a yanked `6.0.4` release that upstream replaced after a Blueprint typing regression.

## Breaking-change risk and migrations

- `flask-cors 6.0.5`: patch release superseding `6.0.4`; no runtime migration identified for this repo's `CORS(app)` usage.
- `pytest 9.1.0`: release notes include doctest/autouse-fixture and deprecation notes; repo search found no doctest collection usage or matching deprecated pytest patterns.
- `redis 8.0.0`: deferred. KEVin imports Redis directly for cache setup and cache operations, and redis-py 8.0.0 changes connection defaults, retry behavior, timeout behavior, and RESP protocol defaults. That should be handled as a separate migration.

## Verification

- Fresh Python `3.12.12` venv install from `requirements.txt`
- `pip check`
- `pip list --outdated --format=json` returned only `redis==7.4.0 -> 8.0.0`
- `pip-audit -r requirements.txt`
- `python -m py_compile kevin.py nvd_processor.py update.py schema/api.py`
