### PR TITLE
fix: preserve cached error response status

### DIFF
--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -4,10 +4,10 @@ from datetime import datetime
 import importlib
 from pathlib import Path
 import sys
+import unittest
 import xml.etree.ElementTree as element_tree
 
 from flask import Flask
-import pytest
 
 from utils.rss_feed import create_rss_feed
 
@@ -76,11 +76,11 @@ def test_cache_keys_include_function_identity_and_path(monkeypatch):
     assert published_key != modified_key
 
 
-@pytest.mark.parametrize("status_code", [400, 404])
-def test_cached_error_tuple_preserves_http_status(monkeypatch, status_code):
+def test_cached_error_tuple_preserves_http_status(monkeypatch):
     """Cached Flask error tuples retain their original HTTP status."""
     monkeypatch.setenv("REDIS_IP", "localhost")
     cache_module = importlib.import_module("utils.cache_manager")
+    test_case = unittest.TestCase()
 
     class MemoryRedis:
         """Store serialized cache values without requiring a Redis server."""
@@ -92,36 +92,47 @@ def test_cached_error_tuple_preserves_http_status(monkeypatch, status_code):
             """Return a cached byte payload when present."""
             return self.values.get(key)
 
-        def setex(self, key, timeout, value):
+        def setex(self, key, _timeout, value):
             """Store a byte payload using the Redis setex call shape."""
             self.values[key] = value
 
-    memory_redis = MemoryRedis()
-    monkeypatch.setattr(
-        cache_module,
-        "cache_manager",
-        cache_module.CacheManager(memory_redis),
-    )
+    for status_code in (400, 404):
+        memory_redis = MemoryRedis()
+        monkeypatch.setattr(
+            cache_module,
+            "cache_manager",
+            cache_module.CacheManager(memory_redis),
+        )
 
-    app = Flask(__name__)
-    handler_calls = 0
+        app = Flask(__name__)
+        handler_calls = 0
+        route = f"/cached-error-{status_code}"
 
-    @app.get(f"/cached-error-{status_code}")
-    @cache_module.kev_cache(timeout=10, key_prefix="cached_error")
-    def cached_error():
-        """Return the tuple shape used by KEVin's cached error routes."""
-        nonlocal handler_calls
-        handler_calls += 1
-        return {"message": "Vulnerability not found"}, status_code
+        def cached_error():
+            """Return the tuple shape used by KEVin's cached error routes."""
+            nonlocal handler_calls
+            handler_calls += 1
+            return {"message": "Vulnerability not found"}, status_code
 
-    client = app.test_client()
-    first_response = client.get(f"/cached-error-{status_code}")
-    cached_response = client.get(f"/cached-error-{status_code}")
+        cached_view = cache_module.kev_cache(
+            timeout=10,
+            key_prefix="cached_error",
+        )(cached_error)
+        app.add_url_rule(
+            route,
+            endpoint=f"cached_error_{status_code}",
+            view_func=cached_view,
+            methods=["GET"],
+        )
 
-    assert first_response.status_code == status_code
-    assert cached_response.status_code == status_code
-    assert cached_response.get_json() == first_response.get_json()
-    assert handler_calls == 1
+        client = app.test_client()
+        first_response = client.get(route)
+        cached_response = client.get(route)
+
+        test_case.assertEqual(first_response.status_code, status_code)
+        test_case.assertEqual(cached_response.status_code, status_code)
+        test_case.assertEqual(cached_response.get_json(), first_response.get_json())
+        test_case.assertEqual(handler_calls, 1)
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -108,11 +108,11 @@ def test_cached_error_tuple_preserves_http_status(monkeypatch):
         handler_calls = 0
         route = f"/cached-error-{status_code}"
 
-        def cached_error():
+        def cached_error(response_status=status_code):
             """Return the tuple shape used by KEVin's cached error routes."""
             nonlocal handler_calls
             handler_calls += 1
-            return {"message": "Vulnerability not found"}, status_code
+            return {"message": "Vulnerability not found"}, response_status
 
         cached_view = cache_module.kev_cache(
             timeout=10,

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import sys
 import xml.etree.ElementTree as element_tree
 
+from flask import Flask
+import pytest
+
 from utils.rss_feed import create_rss_feed
 
 
@@ -71,6 +74,54 @@ def test_cache_keys_include_function_identity_and_path(monkeypatch):
         {"query_items": query_items, "path": "/vuln/modified"},
     )
     assert published_key != modified_key
+
+
+@pytest.mark.parametrize("status_code", [400, 404])
+def test_cached_error_tuple_preserves_http_status(monkeypatch, status_code):
+    """Cached Flask error tuples retain their original HTTP status."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+
+    class MemoryRedis:
+        """Store serialized cache values without requiring a Redis server."""
+
+        def __init__(self):
+            self.values = {}
+
+        def get(self, key):
+            """Return a cached byte payload when present."""
+            return self.values.get(key)
+
+        def setex(self, key, timeout, value):
+            """Store a byte payload using the Redis setex call shape."""
+            self.values[key] = value
+
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+
+    app = Flask(__name__)
+    handler_calls = 0
+
+    @app.get(f"/cached-error-{status_code}")
+    @cache_module.kev_cache(timeout=10, key_prefix="cached_error")
+    def cached_error():
+        """Return the tuple shape used by KEVin's cached error routes."""
+        nonlocal handler_calls
+        handler_calls += 1
+        return {"message": "Vulnerability not found"}, status_code
+
+    client = app.test_client()
+    first_response = client.get(f"/cached-error-{status_code}")
+    cached_response = client.get(f"/cached-error-{status_code}")
+
+    assert first_response.status_code == status_code
+    assert cached_response.status_code == status_code
+    assert cached_response.get_json() == first_response.get_json()
+    assert handler_calls == 1
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -2,7 +2,7 @@
 
 import functools
 import hashlib
-from flask import Response, has_request_context, request
+from flask import Response, has_request_context, make_response, request
 from utils.cache_config import redis_client
 import re
 import orjson
@@ -202,7 +202,9 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
 
             # print(f"[kev_cache] Cache miss for key: {cache_key}")
             result = func(*args, **kwargs)
-            cache_manager.set(cache_key, result, timeout=timeout)
+            # Normalize every Flask-supported return form before serialization so
+            # cache hits preserve the original status, body, and essential headers.
+            cache_manager.set(cache_key, make_response(result), timeout=timeout)
             return result
         return wrapper
     return decorator


### PR DESCRIPTION
## Overview

Fixes a cache serialization bug that changed real Flask `400` and `404` tuple responses into malformed `200` responses on cache hits.

## Root cause

`kev_cache` wrote raw Flask view return values to `CacheManager`. A return such as `({"message": "Vulnerability not found"}, 404)` was serialized by orjson as a JSON array. On a cache hit, Flask received that list as a new response body and assigned the default HTTP 200 status.

## What changed

- Normalize view return values with Flask's `make_response()` before writing them to cache.
- Reuse the existing `Response` cache representation so body, status, and essential headers survive the Redis round-trip.
- Keep the original cache-miss return value, cache keys, TTLs, error-caching policy, and streaming behavior unchanged.
- Add regression coverage for cached 400 and 404 tuple responses, including proof that the second request is served from cache.
- Refactor the regression test to satisfy Bandit, Prospector, and both Pylint analyzers without suppressions.

## Impact

Clients now receive the same HTTP status and JSON body on cache hits as they do on the original cache miss. Error responses can no longer be misreported as successful 200 responses during their cache TTL.

## Validation

- `pytest -q` — 7 passed, with both 400 and 404 exercised
- Exact `/openai/kev` replay with stubbed MongoDB and Redis:
  - missing query parameter: 400 on miss and hit
  - unknown CVE: 404 on miss and hit
- `git diff --check`
- Advanced Security review threads: 16/16 resolved
- CodeQL, Codacy, Bandit, Prospector, and both Pylint analyzers passed
- Independent code review: no Critical or Important findings
- Signed commits verified

Only `utils/cache_manager.py` and `tests/security_regression_test.py` are included; internal design and planning documents are excluded.