### PR TITLE
fix: avoid caching transient server errors

### DIFF
--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -17,6 +17,22 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
+class MemoryRedis:
+    """Store serialized cache values without requiring a Redis server."""
+
+    def __init__(self):
+        """Initialize an empty in-memory Redis value store."""
+        self.values = {}
+
+    def get(self, key):
+        """Return a cached byte payload when present."""
+        return self.values.get(key)
+
+    def setex(self, key, _timeout, value):
+        """Store a byte payload using the Redis setex call shape."""
+        self.values[key] = value
+
+
 def test_rss_feed_escapes_description_html_fields():
     """RSS descriptions escape attacker-controlled HTML fragments."""
     entry = {
@@ -82,20 +98,6 @@ def test_cached_error_tuple_preserves_http_status(monkeypatch):
     cache_module = importlib.import_module("utils.cache_manager")
     test_case = unittest.TestCase()
 
-    class MemoryRedis:
-        """Store serialized cache values without requiring a Redis server."""
-
-        def __init__(self):
-            self.values = {}
-
-        def get(self, key):
-            """Return a cached byte payload when present."""
-            return self.values.get(key)
-
-        def setex(self, key, _timeout, value):
-            """Store a byte payload using the Redis setex call shape."""
-            self.values[key] = value
-
     for status_code in (400, 404):
         memory_redis = MemoryRedis()
         monkeypatch.setattr(
@@ -133,6 +135,51 @@ def test_cached_error_tuple_preserves_http_status(monkeypatch):
         test_case.assertEqual(cached_response.status_code, status_code)
         test_case.assertEqual(cached_response.get_json(), first_response.get_json())
         test_case.assertEqual(handler_calls, 1)
+
+
+def test_server_error_response_is_not_cached(monkeypatch):
+    """A transient server error does not hide a recovered handler response."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+
+    app = Flask(__name__)
+    handler_calls = 0
+
+    def recovering_handler():
+        """Fail once, then return the healthy response clients should observe."""
+        nonlocal handler_calls
+        handler_calls += 1
+        if handler_calls == 1:
+            return {"message": "Temporary backend failure"}, 500
+        return {"message": "Recovered"}, 200
+
+    cached_view = cache_module.kev_cache(
+        timeout=120,
+        key_prefix="recovering_handler",
+    )(recovering_handler)
+    app.add_url_rule(
+        "/recovering-handler",
+        endpoint="recovering_handler",
+        view_func=cached_view,
+        methods=["GET"],
+    )
+
+    client = app.test_client()
+    failed_response = client.get("/recovering-handler")
+    recovered_response = client.get("/recovering-handler")
+    cached_recovery_response = client.get("/recovering-handler")
+
+    assert failed_response.status_code == 500
+    assert recovered_response.status_code == 200
+    assert recovered_response.get_json() == {"message": "Recovered"}
+    assert cached_recovery_response.status_code == 200
+    assert handler_calls == 2
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -142,6 +142,7 @@ def test_server_error_response_is_not_cached(monkeypatch):
     monkeypatch.setenv("REDIS_IP", "localhost")
     cache_module = importlib.import_module("utils.cache_manager")
     memory_redis = MemoryRedis()
+    test_case = unittest.TestCase()
     monkeypatch.setattr(
         cache_module,
         "cache_manager",
@@ -175,11 +176,11 @@ def test_server_error_response_is_not_cached(monkeypatch):
     recovered_response = client.get("/recovering-handler")
     cached_recovery_response = client.get("/recovering-handler")
 
-    assert failed_response.status_code == 500
-    assert recovered_response.status_code == 200
-    assert recovered_response.get_json() == {"message": "Recovered"}
-    assert cached_recovery_response.status_code == 200
-    assert handler_calls == 2
+    test_case.assertEqual(failed_response.status_code, 500)
+    test_case.assertEqual(recovered_response.status_code, 200)
+    test_case.assertEqual(recovered_response.get_json(), {"message": "Recovered"})
+    test_case.assertEqual(cached_recovery_response.status_code, 200)
+    test_case.assertEqual(handler_calls, 2)
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -204,7 +204,10 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             result = func(*args, **kwargs)
             # Normalize every Flask-supported return form before serialization so
             # cache hits preserve the original status, body, and essential headers.
-            cache_manager.set(cache_key, make_response(result), timeout=timeout)
+            response = make_response(result)
+            # Server errors are transient and must not outlive backend recovery.
+            if response.status_code < 500:
+                cache_manager.set(cache_key, response, timeout=timeout)
             return result
         return wrapper
     return decorator


### PR DESCRIPTION
## Summary

- skip Redis persistence for normalized Flask responses with a 5xx status
- preserve existing cache behavior and status replay for non-5xx responses, including intentional 400/404 negative caching
- add a regression that simulates a transient 500, verifies the recovered 200 is visible immediately, and confirms the healthy response is then cached

## Root cause

`kev_cache` normalized every handler result and unconditionally wrote it to Redis. A single transient backend or serialization failure therefore became a cached 5xx response for the full route TTL, hiding recovery from public API clients.

## Impact

Recovered handlers are called again immediately after a server error instead of replaying a cached outage. Successful responses continue to receive normal cache protection.

## Validation

- `uv run --with-requirements requirements.txt pytest -q` (8 passed)
- `git diff --check`