### PR TITLE
Add cache and origin backpressure

### DIFF
--- a/kevin.py
+++ b/kevin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from gevent import spawn, joinall, monkey
+from gevent import monkey
 monkey.patch_all()
 
 
@@ -10,13 +10,19 @@ import logging
 
 # Third-Party Library Imports
 from dotenv import load_dotenv
-from flask import Flask, jsonify, render_template, request, make_response, Response, send_from_directory
+from flask import Flask, jsonify, render_template, request, Response, send_from_directory
 from flask_restful import Api
 from flask_compress import Compress
 from flask_cors import CORS
+from pymongo.errors import PyMongoError
 
 # Project-Specific Imports
 from utils.database import collection, all_vulns_collection
+from utils.backend_capacity import (
+    BackendBusyError,
+    BackendTimeoutError,
+    run_backend_tasks,
+)
 from utils.cache_manager import kev_cache as cache 
 from utils.sanitizer import sanitize_query
 from utils.rss_feed import create_rss_feed
@@ -222,27 +228,17 @@ def get_metrics():
     def count_cves():
         return all_vulns_collection.estimated_document_count()
 
-    # Spawn the greenlets
-    kevs_greenlet = spawn(count_kevs)
-    cves_greenlet = spawn(count_cves)
-
-    greenlets = [kevs_greenlet, cves_greenlet]
-    # Wait for the greenlets to finish with a timeout to prevent hangs
-    joinall(greenlets, timeout=GREENLET_TIMEOUT)
-
-    # If any greenlet is not ready, kill it and return a timeout response
-    if not all(g.ready() for g in greenlets):
-        for g in greenlets:
-            if not g.ready():
-                try:
-                    g.kill(block=False)
-                except Exception:
-                    pass
+    try:
+        kevs_count, cves_count = run_backend_tasks(
+            [count_kevs, count_cves],
+            timeout=GREENLET_TIMEOUT,
+        )
+    except BackendBusyError:
+        return jsonify({"error": "Backend busy"}), 503
+    except BackendTimeoutError:
         return jsonify({"error": "Backend timeout"}), 504
-
-    # Get the results from the greenlets
-    kevs_count = kevs_greenlet.value
-    cves_count = cves_greenlet.value
+    except PyMongoError:
+        return jsonify({"error": "Backend unavailable"}), 503
 
     # Create a dictionary to hold the metrics
     metrics = {
@@ -284,21 +280,17 @@ def cve_exist():
     def fetch_vulnerability():
         return collection.find_one({"cveID": sanitized_cve_id})
 
-    # Spawn the greenlet
-    greenlet = spawn(fetch_vulnerability)
-    # Wait for the greenlet to finish with a timeout
-    joinall([greenlet], timeout=GREENLET_TIMEOUT)
-
-    # Handle timeout
-    if not greenlet.ready():
-        try:
-            greenlet.kill(block=False)
-        except Exception:
-            pass
+    try:
+        vulnerability = run_backend_tasks(
+            [fetch_vulnerability],
+            timeout=GREENLET_TIMEOUT,
+        )[0]
+    except BackendBusyError:
+        return jsonify({"error": "Backend busy"}), 503
+    except BackendTimeoutError:
         return jsonify({"error": "Backend timeout"}), 504
-
-    # Get the result from the greenlet
-    vulnerability = greenlet.value
+    except PyMongoError:
+        return jsonify({"error": "Backend unavailable"}), 503
 
     # If the vulnerability is found, return a JSON response indicating that the CVE ID exists in the KEV database
     if vulnerability:

--- a/schema/api.py
+++ b/schema/api.py
@@ -1,6 +1,24 @@
 # schema/api.py
 
-from utils.database import all_vulns_collection, collection
+from datetime import datetime, timedelta, timezone
+from functools import partial
+import math
+import os
+import re
+
+from dotenv import load_dotenv
+from flask import Response, json, jsonify, make_response, request, stream_with_context
+from flask_restful import Resource
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import PyMongoError
+
+from schema.serializers import (
+    mitre_serializer,
+    nvd_serializer,
+    serialize_all_vulnerability,
+    serialize_githubpocs,
+    serialize_vulnerability,
+)
 from utils.backend_capacity import (
     BackendBusyError,
     BackendTimeoutError,
@@ -12,33 +30,23 @@ from utils.cache_manager import (
     cache_manager,
     kev_cache as cache,
 )
+from utils.database import all_vulns_collection, collection
 from utils.sanitizer import sanitize_query
-from functools import partial
-from flask_restful import Resource
-from flask import request, Response, json, jsonify, make_response, stream_with_context
-from pymongo import ASCENDING, DESCENDING
-from pymongo.errors import PyMongoError
-from datetime import datetime, timedelta, timezone
-import math
-import os
-from schema.serializers import serialize_vulnerability, serialize_all_vulnerability, nvd_serializer, mitre_serializer, serialize_githubpocs
-import re
 
 # Load env using python-dotenv
-from dotenv import load_dotenv
 load_dotenv()
 
 # Fields clients are allowed to sort on for KEV listings. Keep in sync with
 # Mongo indexes so we never trigger an expensive collection scan.
 ALLOWED_KEV_SORT_FIELDS = {"dateAdded", "dueDate", "cveID"}
-MAX_PAGE = max(1, int(os.environ.get("MAX_PAGE", 1000)))
+MAX_PAGE = max(1, int(os.environ.get("MAX_PAGE", "1000")))
 RECENT_KEV_MAX_RESULTS = max(
     1,
-    int(os.environ.get("RECENT_KEV_MAX_RESULTS", 500)),
+    int(os.environ.get("RECENT_KEV_MAX_RESULTS", "500")),
 )
 
 # Timeout in seconds for admitted backend work to finish.
-GREENLET_TIMEOUT = max(1, int(os.environ.get('GREENLET_TIMEOUT', 10)))
+GREENLET_TIMEOUT = max(1, int(os.environ.get('GREENLET_TIMEOUT', "10")))
 
 def validate_page(page):
     """Reject non-positive and unbounded pages before MongoDB skip() calls."""

--- a/schema/api.py
+++ b/schema/api.py
@@ -1,18 +1,27 @@
 # schema/api.py
 
 from utils.database import all_vulns_collection, collection
-from utils.cache_manager import cache_manager, kev_cache as cache
+from utils.backend_capacity import (
+    BackendBusyError,
+    BackendTimeoutError,
+    MAX_BACKEND_CONCURRENCY,
+    run_backend_tasks,
+)
+from utils.cache_manager import (
+    CacheBackendUnavailable,
+    cache_manager,
+    kev_cache as cache,
+)
 from utils.sanitizer import sanitize_query
 from functools import partial
 from flask_restful import Resource
 from flask import request, Response, json, jsonify, make_response, stream_with_context
 from pymongo import ASCENDING, DESCENDING
-from datetime import datetime, timedelta
+from pymongo.errors import PyMongoError
+from datetime import datetime, timedelta, timezone
 import math
 import os
 from schema.serializers import serialize_vulnerability, serialize_all_vulnerability, nvd_serializer, mitre_serializer, serialize_githubpocs
-from gevent import joinall
-from gevent.pool import Pool
 import re
 
 # Load env using python-dotenv
@@ -23,35 +32,13 @@ load_dotenv()
 # Mongo indexes so we never trigger an expensive collection scan.
 ALLOWED_KEV_SORT_FIELDS = {"dateAdded", "dueDate", "cveID"}
 MAX_PAGE = max(1, int(os.environ.get("MAX_PAGE", 1000)))
+RECENT_KEV_MAX_RESULTS = max(
+    1,
+    int(os.environ.get("RECENT_KEV_MAX_RESULTS", 500)),
+)
 
-# Configure the maximum number of concurrent greenlets
-# This helps prevent server overload from too many concurrent operations
-# Ensure we have at least 1 greenlet to prevent crashes
-MAX_GREENLETS = max(1, int(os.environ.get('MAX_GREENLETS', 100)))
-# Timeout (seconds) for joinall to avoid request hangs
+# Timeout in seconds for admitted backend work to finish.
 GREENLET_TIMEOUT = max(1, int(os.environ.get('GREENLET_TIMEOUT', 10)))
-# Create a global pool to limit concurrent greenlets
-GREENLET_POOL = Pool(MAX_GREENLETS)
-
-
-def greenlet_value_or_raise(greenlet):
-    """Return a greenlet's value or re-raise its stored exception."""
-    if not greenlet.ready():
-        return None
-    exc = getattr(greenlet, "exception", None)
-    if exc:
-        raise exc
-    return greenlet.value
-
-
-def kill_unfinished_greenlets(greenlets):
-    """Kill any unfinished greenlets from the provided iterable."""
-    for greenlet in greenlets or []:
-        if not getattr(greenlet, "ready", lambda: True)():
-            try:
-                greenlet.kill(block=False)
-            except Exception:
-                pass
 
 def validate_page(page):
     """Reject non-positive and unbounded pages before MongoDB skip() calls."""
@@ -95,38 +82,42 @@ class cveLandResource(BaseResource):
         # Use partial to create a new function that includes the cve_id in the key prefix
         cache_key_func = partial(self.make_cache_key, cve_id=sanitized_cve_id)
 
-        # Spawn greenlets for concurrent execution using the pool
-        greenlets = []
-        greenlets.append(GREENLET_POOL.spawn(self.get_cached_data, cache_key_func))
-        greenlets.append(GREENLET_POOL.spawn(self.query_vulnerability, sanitized_cve_id))
-
-        # Wait for all greenlets to complete with a timeout
-        joinall(greenlets, timeout=GREENLET_TIMEOUT)
-
-        cached_data = greenlet_value_or_raise(greenlets[0])
-        vulnerability = greenlet_value_or_raise(greenlets[1])
-
-        # Prefer any ready result
-        if cached_data:
-            kill_unfinished_greenlets(greenlets)
+        try:
+            cached_data = self.get_cached_data(cache_key_func)
+        except CacheBackendUnavailable:
+            return self.handle_error("Cache temporarily unavailable", 503)
+        if cached_data is not None:
             return self.make_json_response(cached_data)
-        if vulnerability:
-            data = serialize_all_vulnerability(vulnerability)
-            cache_manager.set(cache_key_func(), data, timeout=180)  # Manually cache ready DB results
-            kill_unfinished_greenlets(greenlets)
-            return self.make_json_response(data)
 
-        # If nothing has finished yet, treat as timeout
-        if not all(g.ready() for g in greenlets):
-            for g in greenlets:
-                if not g.ready():
-                    try:
-                        g.kill(block=False)
-                    except Exception:
-                        pass
-            return self.handle_error("Upstream timeout", 504)
+        cache_key = cache_key_func()
+        with cache_manager.singleflight(cache_key) as acquired:
+            if not acquired:
+                return self.handle_error("Backend busy", 503)
 
-        # Both completed without data
+            try:
+                cached_data = cache_manager.get(cache_key)
+            except CacheBackendUnavailable:
+                return self.handle_error("Cache temporarily unavailable", 503)
+            if cached_data is not None:
+                return self.make_json_response(cached_data)
+
+            try:
+                vulnerability = run_backend_tasks(
+                    [partial(self.query_vulnerability, sanitized_cve_id)],
+                    timeout=GREENLET_TIMEOUT,
+                )[0]
+            except BackendBusyError:
+                return self.handle_error("Backend busy", 503)
+            except BackendTimeoutError:
+                return self.handle_error("Upstream timeout", 504)
+            except PyMongoError:
+                return self.handle_error("Backend unavailable", 503)
+
+            if vulnerability:
+                data = serialize_all_vulnerability(vulnerability)
+                cache_manager.set(cache_key, data, timeout=180)
+                return self.make_json_response(data)
+
         return self.handle_error("Vulnerability not found")
 
     def get_cached_data(self, cache_key_func):
@@ -249,34 +240,45 @@ class VulnerabilityResource(BaseResource):
         elif references_arg != "pocs" and references_arg is not None:
             return self.handle_error("Invalid value for references parameter", 400)
         else:
-            # Spawn greenlets for cache check and database query using the pool
-            greenlets = []
-            greenlets.append(GREENLET_POOL.spawn(self.get_cached_data, sanitized_cve_id))
-            greenlets.append(GREENLET_POOL.spawn(self.query_vulnerability, sanitized_cve_id))
-
-            # Wait for all greenlets to complete with a timeout
-            joinall(greenlets, timeout=GREENLET_TIMEOUT)
-
-            cached_data = greenlet_value_or_raise(greenlets[0])
-            vulnerability = greenlet_value_or_raise(greenlets[1])
-
-            if cached_data:
+            try:
+                cached_data = self.get_cached_data(sanitized_cve_id)
+            except CacheBackendUnavailable:
+                return self.handle_error("Cache temporarily unavailable", 503)
+            if cached_data is not None:
                 data = serialize_vulnerability(cached_data)
-            elif vulnerability:
-                cache_manager.set(sanitized_cve_id, vulnerability)
-                data = serialize_vulnerability(vulnerability)
             else:
-                if not all(g.ready() for g in greenlets):
-                    for g in greenlets:
-                        if not g.ready():
-                            try:
-                                g.kill(block=False)
-                            except Exception:
-                                pass
-                    return self.handle_error("Upstream timeout", 504)
-                return self.handle_error("Vulnerability not found")
+                with cache_manager.singleflight(sanitized_cve_id) as acquired:
+                    if not acquired:
+                        return self.handle_error("Backend busy", 503)
 
-            kill_unfinished_greenlets(greenlets)
+                    try:
+                        cached_data = cache_manager.get(sanitized_cve_id)
+                    except CacheBackendUnavailable:
+                        return self.handle_error("Cache temporarily unavailable", 503)
+                    if cached_data is not None:
+                        data = serialize_vulnerability(cached_data)
+                    else:
+                        try:
+                            vulnerability = run_backend_tasks(
+                                [
+                                    partial(
+                                        self.query_vulnerability,
+                                        sanitized_cve_id,
+                                    )
+                                ],
+                                timeout=GREENLET_TIMEOUT,
+                            )[0]
+                        except BackendBusyError:
+                            return self.handle_error("Backend busy", 503)
+                        except BackendTimeoutError:
+                            return self.handle_error("Upstream timeout", 504)
+                        except PyMongoError:
+                            return self.handle_error("Backend unavailable", 503)
+
+                        if not vulnerability:
+                            return self.handle_error("Vulnerability not found")
+                        cache_manager.set(sanitized_cve_id, vulnerability)
+                        data = serialize_vulnerability(vulnerability)
         return self.make_json_response(data)
 
     def get_cached_data(self, sanitized_cve_id):
@@ -375,7 +377,7 @@ class AllKevVulnerabilitiesResource(BaseResource):
                 "total_pages": total_pages,
                 "vulnerabilities": [serialize_vulnerability(v) for v in vulnerabilities]
             })
-        except Exception as e:
+        except Exception:
             return self.handle_error("An internal server error occurred! ", 500)
 
     def count_documents(self, query):
@@ -406,6 +408,7 @@ class RecentKevVulnerabilitiesResource(BaseResource):
 
         Query Parameters:
         - days (int): The number of days to look back for recent vulnerabilities.
+        - limit (int): Maximum records to stream, capped by server configuration.
 
         Returns:
         Response: A JSON response containing a list of recent vulnerabilities
@@ -419,16 +422,30 @@ class RecentKevVulnerabilitiesResource(BaseResource):
         # Limit days to a maximum of 100
         if days > 100:
             return self.handle_error("Exceeded the maximum limit of 100 days", 400)
+        result_limit = request.args.get(
+            "limit",
+            default=RECENT_KEV_MAX_RESULTS,
+            type=int,
+        )
+        if result_limit is None or result_limit < 1:
+            return self.handle_error("Invalid value for limit", 400)
+        if result_limit > RECENT_KEV_MAX_RESULTS:
+            return self.handle_error(
+                f"Exceeded the maximum limit of {RECENT_KEV_MAX_RESULTS} results",
+                400,
+            )
         # Calculate the cutoff date based on the 'days' parameter
-        cutoff_date = datetime.utcnow() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
         cutoff_date_str = cutoff_date.strftime("%Y-%m-%d")
         
         # Use server-side filtering - only fetch vulnerabilities with dateAdded >= cutoff_date
-        cursor = collection.find({"dateAdded": {"$gte": cutoff_date_str}})
+        cursor = collection.find(
+            {"dateAdded": {"$gte": cutoff_date_str}}
+        ).limit(result_limit)
 
         # Stream the cursor in manageable batches to avoid loading every
         # vulnerability into memory at once.
-        batch_size = max(1, min(MAX_GREENLETS, 200))
+        batch_size = max(1, min(MAX_BACKEND_CONCURRENCY, 200))
         cursor = cursor.batch_size(batch_size)
 
         def stream_vulnerabilities():
@@ -524,32 +541,27 @@ class RecentVulnerabilitiesByDaysResource(BaseResource):
             else "namespaces.nvd_nist_gov.cve.lastModified"
         )
 
-        # Create a list of greenlets for concurrent execution using the pool
-        greenlets = []
-
-        # Spawn a greenlet for counting total entries
-        greenlets.append(GREENLET_POOL.spawn(self.count_total_entries, field, cutoff_date))
-        # Spawn a greenlet for querying the database with the correct parameters
-        greenlets.append(GREENLET_POOL.spawn(self.query_database, field, cutoff_date, page, per_page, sort_order=-1))  # -1 for descending order
-
-        # Wait for all greenlets to complete with a timeout
-        joinall(greenlets, timeout=GREENLET_TIMEOUT)
-
-        # Get the total entries and recent vulnerabilities list if ready
-        total_entries_ready = greenlets[0].ready()
-        list_ready = greenlets[1].ready()
-
-        if not (total_entries_ready and list_ready):
-            for g in greenlets:
-                if not g.ready():
-                    try:
-                        g.kill(block=False)
-                    except Exception:
-                        pass
+        try:
+            total_entries, recent_vulnerabilities_list = run_backend_tasks(
+                [
+                    partial(self.count_total_entries, field, cutoff_date),
+                    partial(
+                        self.query_database,
+                        field,
+                        cutoff_date,
+                        page,
+                        per_page,
+                        sort_order=-1,
+                    ),
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
             return self.handle_error("Upstream timeout", 504)
-
-        total_entries = greenlet_value_or_raise(greenlets[0])
-        recent_vulnerabilities_list = greenlet_value_or_raise(greenlets[1])
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
 
         # Check if recent_vulnerabilities_list is None
         if recent_vulnerabilities_list is None:

--- a/schema/api.py
+++ b/schema/api.py
@@ -449,7 +449,7 @@ class RecentKevVulnerabilitiesResource(BaseResource):
         # Use server-side filtering - only fetch vulnerabilities with dateAdded >= cutoff_date
         cursor = collection.find(
             {"dateAdded": {"$gte": cutoff_date_str}}
-        ).limit(result_limit)
+        ).sort("dateAdded", DESCENDING).limit(result_limit)
 
         # Stream the cursor in manageable batches to avoid loading every
         # vulnerability into memory at once.

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -4,10 +4,17 @@ from datetime import datetime
 import importlib
 from pathlib import Path
 import sys
+import types
 import unittest
 import xml.etree.ElementTree as element_tree
 
 from flask import Flask
+from gevent import event, joinall, sleep, spawn
+import pytest
+from pymongo.errors import WaitQueueTimeoutError
+from redis import BlockingConnectionPool
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import MaxConnectionsError
 
 from utils.rss_feed import create_rss_feed
 
@@ -31,6 +38,32 @@ class MemoryRedis:
     def setex(self, key, _timeout, value):
         """Store a byte payload using the Redis setex call shape."""
         self.values[key] = value
+
+
+class ExhaustedRedis:
+    """Simulate a Redis connection pool that cannot serve another command."""
+
+    def __init__(self):
+        """Track how often callers attempt to reach the exhausted pool."""
+        self.get_calls = 0
+
+    def get(self, _key):
+        """Raise the exception emitted by redis-py when its pool is full."""
+        self.get_calls += 1
+        raise MaxConnectionsError("Too many connections")
+
+
+class FailingWriteRedis:
+    """Simulate a Redis server that rejects cache writes."""
+
+    def __init__(self):
+        """Track attempted writes while the circuit opens."""
+        self.set_calls = 0
+
+    def setex(self, _key, _timeout, _value):
+        """Raise a Redis connection failure for every attempted write."""
+        self.set_calls += 1
+        raise RedisConnectionError("Redis unavailable")
 
 
 def test_rss_feed_escapes_description_html_fields():
@@ -181,6 +214,382 @@ def test_server_error_response_is_not_cached(monkeypatch):
     test_case.assertEqual(recovered_response.get_json(), {"message": "Recovered"})
     test_case.assertEqual(cached_recovery_response.status_code, 200)
     test_case.assertEqual(handler_calls, 2)
+
+
+def test_cache_pool_exhaustion_returns_503_without_calling_origin(monkeypatch):
+    """Redis pool exhaustion sheds load instead of cascading into MongoDB."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    exhausted_redis = ExhaustedRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(exhausted_redis),
+    )
+
+    app = Flask(__name__)
+    handler_calls = 0
+
+    def origin_handler():
+        """Record whether cache failure incorrectly falls through to origin."""
+        nonlocal handler_calls
+        handler_calls += 1
+        return {"message": "origin response"}, 200
+
+    cached_view = cache_module.kev_cache(
+        timeout=120,
+        key_prefix="cache_exhaustion",
+    )(origin_handler)
+    app.add_url_rule(
+        "/cache-exhaustion",
+        endpoint="cache_exhaustion",
+        view_func=cached_view,
+        methods=["GET"],
+    )
+
+    first_response = app.test_client().get("/cache-exhaustion")
+    second_response = app.test_client().get("/cache-exhaustion")
+
+    assert first_response.status_code == 503
+    assert second_response.status_code == 503
+    assert first_response.get_json() == {"error": "Cache temporarily unavailable"}
+    assert handler_calls == 0
+    assert exhausted_redis.get_calls == 1
+
+
+def test_redis_pool_wait_is_bounded(monkeypatch):
+    """Redis uses a larger blocking pool with a short bounded checkout wait."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_config = importlib.import_module("utils.cache_config")
+    monkeypatch.setattr(cache_config, "MAX_CONNECTIONS", 100)
+    monkeypatch.setattr(cache_config, "POOL_WAIT_TIMEOUT", 0.05)
+
+    redis_client, _config = cache_config.setup_cache_config("localhost")
+    pool = redis_client.connection_pool
+
+    assert isinstance(pool, BlockingConnectionPool)
+    assert pool.max_connections == 100
+    assert pool.timeout == 0.05
+
+
+def test_cache_write_circuit_skips_repeated_failed_writes(monkeypatch):
+    """One failed cache write opens the circuit for subsequent responses."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    failing_redis = FailingWriteRedis()
+    manager = cache_module.CacheManager(
+        failing_redis,
+        circuit_breaker_seconds=1,
+    )
+
+    manager.set("first_write", {"value": 1})
+    manager.set("second_write", {"value": 2})
+
+    assert failing_redis.set_calls == 1
+
+
+def test_cache_hit_verifies_stored_bytes_without_reserializing(monkeypatch):
+    """Cache hits retain integrity checks without rebuilding canonical JSON."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    manager = cache_module.CacheManager(memory_redis)
+    expected = {"cveID": "CVE-2026-0001", "knownExploited": True}
+
+    manager.set("checksum_hot_path", expected)
+
+    def unexpected_legacy_checksum(_value):
+        """Fail if the legacy reserialization checksum path is exercised."""
+        raise AssertionError("cache hit reserialized its value")
+
+    monkeypatch.setattr(
+        cache_module,
+        "generate_checksum",
+        unexpected_legacy_checksum,
+    )
+
+    assert manager.get("checksum_hot_path") == expected
+
+
+def test_cache_integrity_rejects_tampered_binary_envelope(monkeypatch):
+    """The optimized cache envelope still rejects modified Redis values."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    manager = cache_module.CacheManager(memory_redis)
+
+    manager.set("tampered_payload", {"value": "safe"})
+    memory_redis.values["tampered_payload"] = memory_redis.values[
+        "tampered_payload"
+    ].replace(b"safe", b"evil", 1)
+
+    assert manager.get("tampered_payload") is None
+
+
+def test_cache_miss_singleflight_runs_one_origin_loader(monkeypatch):
+    """Concurrent misses for one key share a single origin computation."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(
+            memory_redis,
+            singleflight_wait_seconds=0.2,
+        ),
+    )
+
+    app = Flask(__name__)
+    handler_calls = 0
+
+    def slow_origin_handler():
+        """Yield long enough for another request to observe the in-flight key."""
+        nonlocal handler_calls
+        handler_calls += 1
+        sleep(0.05)
+        return {"message": "loaded once"}, 200
+
+    cached_view = cache_module.kev_cache(
+        timeout=120,
+        key_prefix="singleflight",
+    )(slow_origin_handler)
+    app.add_url_rule(
+        "/singleflight",
+        endpoint="singleflight",
+        view_func=cached_view,
+        methods=["GET"],
+    )
+
+    requests = [
+        spawn(lambda: app.test_client().get("/singleflight")),
+        spawn(lambda: app.test_client().get("/singleflight")),
+    ]
+    joinall(requests)
+
+    assert [request.value.status_code for request in requests] == [200, 200]
+    assert [request.value.get_json() for request in requests] == [
+        {"message": "loaded once"},
+        {"message": "loaded once"},
+    ]
+    assert handler_calls == 1
+
+
+def test_cached_route_maps_mongo_checkout_timeout_to_503(monkeypatch):
+    """A bounded Mongo checkout failure is exposed as retryable overload."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(MemoryRedis()),
+    )
+
+    app = Flask(__name__)
+
+    def saturated_origin_handler():
+        """Raise the PyMongo error emitted after waitQueueTimeoutMS elapses."""
+        raise WaitQueueTimeoutError("Timed out while checking out a connection")
+
+    cached_view = cache_module.kev_cache(
+        timeout=120,
+        key_prefix="mongo_checkout_timeout",
+    )(saturated_origin_handler)
+    app.add_url_rule(
+        "/mongo-checkout-timeout",
+        endpoint="mongo_checkout_timeout",
+        view_func=cached_view,
+        methods=["GET"],
+    )
+
+    response = app.test_client().get("/mongo-checkout-timeout")
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "Backend temporarily unavailable"}
+
+
+def test_backend_capacity_rejects_work_instead_of_waiting_for_a_slot():
+    """Backend admission fails fast while all database slots are occupied."""
+    backend_module = importlib.import_module("utils.backend_capacity")
+    limiter = backend_module.BackendCapacity(max_concurrency=1)
+    release_first_task = event.Event()
+    first_task_started = event.Event()
+
+    def blocking_task():
+        """Hold the only backend slot until the assertion has run."""
+        first_task_started.set()
+        release_first_task.wait()
+        return "first"
+
+    first_request = spawn(
+        limiter.run_tasks,
+        [blocking_task],
+        1,
+    )
+    first_task_started.wait(timeout=0.5)
+
+    with pytest.raises(backend_module.BackendBusyError):
+        limiter.run_tasks([lambda: "second"], timeout=1)
+
+    release_first_task.set()
+    first_request.join(timeout=0.5)
+    assert first_request.value == ["first"]
+
+
+def test_mongo_checkout_wait_has_a_bounded_timeout():
+    """MongoClient checkout cannot wait indefinitely behind a full pool."""
+    source = (ROOT / "utils" / "database.py").read_text()
+
+    assert 'MONGO_WAIT_QUEUE_TIMEOUT_MS", 500' in source
+    assert "waitQueueTimeoutMS=wait_queue_timeout" in source
+
+
+@pytest.mark.parametrize(
+    ("resource_name", "cached_value", "path"),
+    [
+        (
+            "cveLandResource",
+            {"cveID": "CVE-2026-0001", "description": "cached"},
+            "/vuln/CVE-2026-0001",
+        ),
+        (
+            "VulnerabilityResource",
+            {
+                "_id": "record-1",
+                "cveID": "CVE-2026-0001",
+                "dateAdded": "2026-01-01",
+                "dueDate": "2026-01-22",
+            },
+            "/kev/CVE-2026-0001",
+        ),
+    ],
+)
+def test_manual_cache_resources_do_not_query_mongo_on_hit(
+    monkeypatch,
+    resource_name,
+    cached_value,
+    path,
+):
+    """Manual cache resources query MongoDB only after a real cache miss."""
+
+    class CountingCollection:
+        """Count database lookups that a cache hit should avoid."""
+
+        def __init__(self):
+            """Initialize an untouched fake collection."""
+            self.find_one_calls = 0
+
+        def find_one(self, _query):
+            """Record the unexpected lookup and return no database value."""
+            self.find_one_calls += 1
+            return None
+
+    class StaticCache:
+        """Return one preloaded cache value for every requested key."""
+
+        def get(self, _key):
+            """Return the value that should satisfy the resource."""
+            return cached_value
+
+        def set(self, _key, _value, timeout=120):
+            """Reject cache writes because a hit must never refill the key."""
+            raise AssertionError(f"unexpected cache write with timeout {timeout}")
+
+    fake_collection = CountingCollection()
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = fake_collection
+    fake_database.all_vulns_collection = fake_collection
+    cache_module = importlib.import_module("utils.cache_manager")
+    monkeypatch.setattr(cache_module, "cache_manager", StaticCache())
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        api_module = importlib.import_module("schema.api")
+        resource = getattr(api_module, resource_name)()
+        app = Flask(__name__)
+        with app.test_request_context(path):
+            response = resource.get("CVE-2026-0001")
+    finally:
+        sys.modules.pop("schema.api", None)
+
+    assert response.status_code == 200
+    assert fake_collection.find_one_calls == 0
+
+
+def test_kevin_routes_use_bounded_backend_admission():
+    """Metrics and existence routes do not create uncapped greenlets."""
+    source = (ROOT / "kevin.py").read_text()
+
+    assert "from gevent import spawn" not in source
+    assert source.count("run_backend_tasks(") >= 2
+    assert "except BackendBusyError:" in source
+
+
+def test_schema_resources_never_block_in_greenlet_pool_spawn():
+    """Schema routes use fail-fast backend admission rather than Pool.spawn."""
+    source = (ROOT / "schema" / "api.py").read_text()
+
+    assert "GREENLET_POOL.spawn" not in source
+    assert "Pool(MAX_GREENLETS)" not in source
+    assert source.count("run_backend_tasks(") >= 3
+
+
+def test_recent_kev_stream_applies_requested_bounded_limit(monkeypatch):
+    """The recent KEV cursor is capped before a streaming response begins."""
+
+    class RecordingCursor:
+        """Record cursor bounds without requiring a running MongoDB server."""
+
+        def __init__(self):
+            """Initialize a cursor with no configured bound."""
+            self.limit_value = None
+
+        def limit(self, value):
+            """Record and return the maximum number of streamed records."""
+            self.limit_value = value
+            return self
+
+        def batch_size(self, _value):
+            """Preserve the cursor call chain used by the resource."""
+            return self
+
+        def close(self):
+            """Match the PyMongo cursor cleanup interface."""
+
+        def __iter__(self):
+            """Return an empty iterator because only query shape is tested."""
+            return iter(())
+
+    class RecentCollection:
+        """Return the recording cursor for a recent-vulnerability query."""
+
+        def __init__(self):
+            """Create one reusable cursor for assertion."""
+            self.cursor = RecordingCursor()
+
+        def find(self, _query):
+            """Return the cursor that records the applied result cap."""
+            return self.cursor
+
+    recent_collection = RecentCollection()
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = recent_collection
+    fake_database.all_vulns_collection = recent_collection
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        api_module = importlib.import_module("schema.api")
+        resource = api_module.RecentKevVulnerabilitiesResource()
+        app = Flask(__name__)
+        with app.test_request_context("/kev/recent?days=100&limit=25"):
+            response = resource.get.__wrapped__(resource)
+    finally:
+        sys.modules.pop("schema.api", None)
+
+    assert response.status_code == 200
+    assert recent_collection.cursor.limit_value == 25
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -436,6 +436,28 @@ def test_backend_capacity_rejects_work_instead_of_waiting_for_a_slot():
     assert first_request.value == ["first"]
 
 
+def test_backend_capacity_runs_request_tasks_sequentially_with_one_slot():
+    """One admitted request can complete multiple tasks with one backend slot."""
+    backend_module = importlib.import_module("utils.backend_capacity")
+    limiter = backend_module.BackendCapacity(max_concurrency=1)
+    execution_order = []
+
+    def first_task():
+        """Record and return the first sequential result."""
+        execution_order.append("first")
+        return 1
+
+    def second_task():
+        """Record and return the second sequential result."""
+        execution_order.append("second")
+        return 2
+
+    results = limiter.run_tasks([first_task, second_task], timeout=1)
+
+    assert results == [1, 2]
+    assert execution_order == ["first", "second"]
+
+
 def test_mongo_checkout_wait_has_a_bounded_timeout():
     """MongoClient checkout cannot wait indefinitely behind a full pool."""
     source = (ROOT / "utils" / "database.py").read_text()
@@ -544,10 +566,17 @@ def test_recent_kev_stream_applies_requested_bounded_limit(monkeypatch):
         def __init__(self):
             """Initialize a cursor with no configured bound."""
             self.limit_value = None
+            self.operations = []
+
+        def sort(self, key, direction):
+            """Record the deterministic sort applied before the result cap."""
+            self.operations.append(("sort", key, direction))
+            return self
 
         def limit(self, value):
             """Record and return the maximum number of streamed records."""
             self.limit_value = value
+            self.operations.append(("limit", value))
             return self
 
         def batch_size(self, _value):
@@ -590,6 +619,10 @@ def test_recent_kev_stream_applies_requested_bounded_limit(monkeypatch):
 
     assert response.status_code == 200
     assert recent_collection.cursor.limit_value == 25
+    assert recent_collection.cursor.operations == [
+        ("sort", "dateAdded", api_module.DESCENDING),
+        ("limit", 25),
+    ]
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -440,7 +440,7 @@ def test_mongo_checkout_wait_has_a_bounded_timeout():
     """MongoClient checkout cannot wait indefinitely behind a full pool."""
     source = (ROOT / "utils" / "database.py").read_text()
 
-    assert 'MONGO_WAIT_QUEUE_TIMEOUT_MS", 500' in source
+    assert 'MONGO_WAIT_QUEUE_TIMEOUT_MS", "500"' in source
     assert "waitQueueTimeoutMS=wait_queue_timeout" in source
 
 

--- a/utils/backend_capacity.py
+++ b/utils/backend_capacity.py
@@ -44,25 +44,34 @@ class BackendCapacity:
                 raise BackendBusyError("Database concurrency limit reached")
             reserved += 1
 
-    def _run_reserved_task(self, task):
-        """Run one admitted task and release its slot only after it stops."""
+    def _run_reserved_tasks(self, indexed_tasks, results):
+        """Run one sequential task lane and release its reserved slot."""
         try:
-            return task()
+            for index, task in indexed_tasks:
+                results[index] = task()
         finally:
             self._slots.release()
 
     def run_tasks(self, tasks, timeout=BACKEND_TIMEOUT):
-        """Run admitted callables concurrently or fail before spawning any."""
+        """Run callables with bounded parallelism or fail before spawning any."""
         tasks = list(tasks)
         if not tasks:
             return []
 
-        self._reserve(len(tasks))
+        worker_count = min(len(tasks), self.max_concurrency)
+        self._reserve(worker_count)
+        task_lanes = [[] for _index in range(worker_count)]
+        results = [None] * len(tasks)
+        for index, task in enumerate(tasks):
+            task_lanes[index % worker_count].append((index, task))
+
         greenlets = []
-        unassigned_slots = len(tasks)
+        unassigned_slots = worker_count
         try:
-            for task in tasks:
-                greenlets.append(spawn(self._run_reserved_task, task))
+            for task_lane in task_lanes:
+                greenlets.append(
+                    spawn(self._run_reserved_tasks, task_lane, results)
+                )
                 unassigned_slots -= 1
         except Exception:
             # Slots already assigned to greenlets are released by their
@@ -83,7 +92,7 @@ class BackendCapacity:
         for greenlet in greenlets:
             if greenlet.exception is not None:
                 raise greenlet.exception
-        return [greenlet.value for greenlet in greenlets]
+        return results
 
 
 BACKEND_CAPACITY = BackendCapacity(MAX_BACKEND_CONCURRENCY)

--- a/utils/backend_capacity.py
+++ b/utils/backend_capacity.py
@@ -1,0 +1,94 @@
+"""Fail-fast admission control for MongoDB work executed by gevent workers."""
+
+import os
+
+from gevent import joinall, spawn
+from gevent.lock import BoundedSemaphore
+
+
+MONGO_MAX_POOL_SIZE = max(1, int(os.getenv("MONGO_MAX_POOL_SIZE", "20")))
+REQUESTED_BACKEND_CONCURRENCY = max(
+    1,
+    int(os.getenv("MAX_GREENLETS", str(MONGO_MAX_POOL_SIZE))),
+)
+MAX_BACKEND_CONCURRENCY = min(
+    MONGO_MAX_POOL_SIZE,
+    REQUESTED_BACKEND_CONCURRENCY,
+)
+BACKEND_TIMEOUT = max(0.1, float(os.getenv("GREENLET_TIMEOUT", "10")))
+
+
+class BackendBusyError(RuntimeError):
+    """Signal that no database capacity is available for new work."""
+
+
+class BackendTimeoutError(TimeoutError):
+    """Signal that admitted database work exceeded the request deadline."""
+
+
+class BackendCapacity:
+    """Reserve bounded database slots before starting cooperative tasks."""
+
+    def __init__(self, max_concurrency):
+        """Create an admission controller with at least one backend slot."""
+        self.max_concurrency = max(1, int(max_concurrency))
+        self._slots = BoundedSemaphore(self.max_concurrency)
+
+    def _reserve(self, count):
+        """Reserve every requested slot atomically from the caller's view."""
+        reserved = 0
+        for _index in range(count):
+            if not self._slots.acquire(blocking=False):
+                for _reserved_index in range(reserved):
+                    self._slots.release()
+                raise BackendBusyError("Database concurrency limit reached")
+            reserved += 1
+
+    def _run_reserved_task(self, task):
+        """Run one admitted task and release its slot only after it stops."""
+        try:
+            return task()
+        finally:
+            self._slots.release()
+
+    def run_tasks(self, tasks, timeout=BACKEND_TIMEOUT):
+        """Run admitted callables concurrently or fail before spawning any."""
+        tasks = list(tasks)
+        if not tasks:
+            return []
+
+        self._reserve(len(tasks))
+        greenlets = []
+        unassigned_slots = len(tasks)
+        try:
+            for task in tasks:
+                greenlets.append(spawn(self._run_reserved_task, task))
+                unassigned_slots -= 1
+        except Exception:
+            # Slots already assigned to greenlets are released by their
+            # wrappers; only reservations without a greenlet are returned here.
+            for _index in range(unassigned_slots):
+                self._slots.release()
+            for greenlet in greenlets:
+                greenlet.kill(block=False)
+            raise
+
+        joinall(greenlets, timeout=timeout)
+        unfinished = [greenlet for greenlet in greenlets if not greenlet.ready()]
+        if unfinished:
+            for greenlet in unfinished:
+                greenlet.kill(block=False)
+            raise BackendTimeoutError("Database work exceeded its deadline")
+
+        for greenlet in greenlets:
+            if greenlet.exception is not None:
+                raise greenlet.exception
+        return [greenlet.value for greenlet in greenlets]
+
+
+BACKEND_CAPACITY = BackendCapacity(MAX_BACKEND_CONCURRENCY)
+
+
+def run_backend_tasks(tasks, timeout=BACKEND_TIMEOUT):
+    """Run database callables through the shared per-worker capacity limit."""
+    return BACKEND_CAPACITY.run_tasks(tasks, timeout=timeout)

--- a/utils/cache_config.py
+++ b/utils/cache_config.py
@@ -1,5 +1,5 @@
 import os
-from redis import StrictRedis, ConnectionPool
+from redis import BlockingConnectionPool, StrictRedis
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -9,9 +9,12 @@ load_dotenv()
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 CACHE_DEFAULT_TIMEOUT = int(os.getenv("CACHE_DEFAULT_TIMEOUT", 600))  # Default cache timeout
 CACHE_KEY_PREFIX = os.getenv("CACHE_KEY_PREFIX", "kev_")
-MAX_CONNECTIONS = int(os.getenv("MAX_CONNECTIONS", 20))
-SOCKET_TIMEOUT = int(os.getenv("SOCKET_TIMEOUT", 10))  # Socket timeout for Redis connections in seconds
-SOCKET_CONNECT_TIMEOUT = int(os.getenv("SOCKET_CONNECT_TIMEOUT", 10))  # Timeout for establishing a connection
+MAX_CONNECTIONS = int(
+    os.getenv("REDIS_MAX_CONNECTIONS", os.getenv("MAX_CONNECTIONS", 100))
+)
+POOL_WAIT_TIMEOUT = float(os.getenv("REDIS_POOL_WAIT_TIMEOUT", "0.05"))
+SOCKET_TIMEOUT = float(os.getenv("SOCKET_TIMEOUT", "1"))
+SOCKET_CONNECT_TIMEOUT = float(os.getenv("SOCKET_CONNECT_TIMEOUT", "1"))
 
 def setup_cache_config(redis_host):
     """
@@ -21,14 +24,16 @@ def setup_cache_config(redis_host):
     if not redis_host:
         raise ValueError("Redis host must be specified")
 
-    # Create a connection pool for Redis with proper timeouts
-    pool = ConnectionPool(
+    # Wait briefly for a reusable connection instead of failing immediately or
+    # blocking a request indefinitely when the pool reaches its limit.
+    pool = BlockingConnectionPool(
         host=redis_host,
         port=REDIS_PORT,
         db=0,  # Default Redis DB
         max_connections=MAX_CONNECTIONS,
+        timeout=POOL_WAIT_TIMEOUT,
         socket_timeout=SOCKET_TIMEOUT,  # Timeout for socket operations
-        socket_connect_timeout=SOCKET_CONNECT_TIMEOUT  # Timeout for connection establishment
+        socket_connect_timeout=SOCKET_CONNECT_TIMEOUT,  # Timeout for connection establishment
     )
 
     # Create a Redis client using the connection pool

--- a/utils/cache_config.py
+++ b/utils/cache_config.py
@@ -1,16 +1,17 @@
 import os
-from redis import BlockingConnectionPool, StrictRedis
+
 from dotenv import load_dotenv
+from redis import BlockingConnectionPool, StrictRedis
 
 # Load environment variables from .env file
 load_dotenv()
 
 # Constants for Redis configuration
-REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
-CACHE_DEFAULT_TIMEOUT = int(os.getenv("CACHE_DEFAULT_TIMEOUT", 600))  # Default cache timeout
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+CACHE_DEFAULT_TIMEOUT = int(os.getenv("CACHE_DEFAULT_TIMEOUT", "600"))  # Default cache timeout
 CACHE_KEY_PREFIX = os.getenv("CACHE_KEY_PREFIX", "kev_")
 MAX_CONNECTIONS = int(
-    os.getenv("REDIS_MAX_CONNECTIONS", os.getenv("MAX_CONNECTIONS", 100))
+    os.getenv("REDIS_MAX_CONNECTIONS", os.getenv("MAX_CONNECTIONS", "100"))
 )
 POOL_WAIT_TIMEOUT = float(os.getenv("REDIS_POOL_WAIT_TIMEOUT", "0.05"))
 SOCKET_TIMEOUT = float(os.getenv("SOCKET_TIMEOUT", "1"))

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -2,7 +2,16 @@
 
 import functools
 import hashlib
+import hmac
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager
 from flask import Response, has_request_context, make_response, request
+from gevent.lock import Semaphore
+from pymongo.errors import PyMongoError
+from redis.exceptions import RedisError
 from utils.cache_config import redis_client
 import re
 import orjson
@@ -12,6 +21,22 @@ from datetime import datetime
 
 # Regular expression for safe cache keys
 SAFE_KEY_RE = re.compile(r"^[\w\-:]+$")
+CACHE_ENVELOPE_PREFIX = b"kevin-cache-v2:"
+logger = logging.getLogger(__name__)
+
+
+class CacheBackendUnavailable(RuntimeError):
+    """Signal that Redis is unavailable and origin load must be shed."""
+
+
+class _SingleflightEntry:
+    """Track one keyed fill lock and every request currently referencing it."""
+
+    def __init__(self):
+        """Create an unlocked fill slot with no registered users."""
+        self.lock = Semaphore(1)
+        self.users = 0
+
 
 def sanitize_cache_key(key):
     """Ensure cache keys are safe and valid."""
@@ -100,23 +125,111 @@ def generate_checksum(data):
         data_bytes = orjson.dumps(safe_data, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(data_bytes).hexdigest()
 
+
+def serialize_cache_entry(value):
+    """Serialize one integrity-protected value without duplicating its JSON."""
+    safe_value = make_orjson_safe(value)
+    value_bytes = orjson.dumps(safe_value, option=orjson.OPT_SORT_KEYS)
+    checksum = hashlib.sha256(value_bytes).hexdigest().encode("ascii")
+    return CACHE_ENVELOPE_PREFIX + checksum + b":" + value_bytes
+
+
+def deserialize_cache_entry(cached_data):
+    """Verify and decode current or legacy cache payloads."""
+    if cached_data.startswith(CACHE_ENVELOPE_PREFIX):
+        envelope = cached_data[len(CACHE_ENVELOPE_PREFIX):]
+        stored_checksum, separator, value_bytes = envelope.partition(b":")
+        if not separator:
+            raise ValueError("Cache envelope is missing its value separator.")
+
+        generated_checksum = hashlib.sha256(value_bytes).hexdigest().encode("ascii")
+        if not hmac.compare_digest(generated_checksum, stored_checksum):
+            raise ValueError("Cache integrity check failed.")
+        return orjson.loads(value_bytes)
+
+    # Legacy entries remain readable during rolling deployments and naturally
+    # disappear when their existing TTL expires.
+    legacy_entry = orjson.loads(cached_data)
+    value = legacy_entry.get("value")
+    stored_checksum = legacy_entry.get("checksum")
+    if generate_checksum(value) != stored_checksum:
+        raise ValueError("Cache integrity check failed.")
+    return value
+
+
 class CacheManager:
-    def __init__(self, redis_client):
+    def __init__(
+        self,
+        redis_client,
+        circuit_breaker_seconds=None,
+        singleflight_wait_seconds=None,
+        time_func=None,
+    ):
+        """Initialize Redis access with a short per-worker failure circuit."""
         self.redis_client = redis_client
+        self.circuit_breaker_seconds = (
+            float(os.getenv("CACHE_CIRCUIT_BREAKER_SECONDS", "1"))
+            if circuit_breaker_seconds is None
+            else max(0.0, float(circuit_breaker_seconds))
+        )
+        self.singleflight_wait_seconds = (
+            float(os.getenv("CACHE_SINGLEFLIGHT_WAIT_SECONDS", "0.25"))
+            if singleflight_wait_seconds is None
+            else max(0.0, float(singleflight_wait_seconds))
+        )
+        self._time = time.monotonic if time_func is None else time_func
+        self._unavailable_until = 0.0
+        self._singleflight_entries = {}
+        self._singleflight_guard = threading.Lock()
+
+    def _ensure_backend_available(self):
+        """Fail fast while the Redis failure circuit remains open."""
+        if self._time() < self._unavailable_until:
+            raise CacheBackendUnavailable("Redis failure circuit is open")
+
+    def _mark_backend_unavailable(self):
+        """Open the Redis failure circuit for the configured cooldown."""
+        self._unavailable_until = self._time() + self.circuit_breaker_seconds
+
+    def _mark_backend_available(self):
+        """Close the Redis failure circuit after a successful command."""
+        self._unavailable_until = 0.0
+
+    @contextmanager
+    def singleflight(self, key):
+        """Yield whether this request acquired the bounded fill slot for key."""
+        with self._singleflight_guard:
+            entry = self._singleflight_entries.get(key)
+            if entry is None:
+                entry = _SingleflightEntry()
+                self._singleflight_entries[key] = entry
+            entry.users += 1
+
+        acquired = entry.lock.acquire(timeout=self.singleflight_wait_seconds)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                entry.lock.release()
+            with self._singleflight_guard:
+                entry.users -= 1
+                if entry.users == 0:
+                    self._singleflight_entries.pop(key, None)
 
     def get(self, key):
         """Retrieve data from the cache by key."""
-        cached_data = self.redis_client.get(key)
+        self._ensure_backend_available()
+        try:
+            cached_data = self.redis_client.get(key)
+        except RedisError as exc:
+            self._mark_backend_unavailable()
+            raise CacheBackendUnavailable("Redis cache read failed") from exc
+
+        self._mark_backend_available()
         if not cached_data:
             return None
         try:
-            # orjson.loads expects bytes
-            cached_data = orjson.loads(cached_data)
-            value = cached_data.get("value")
-            stored_checksum = cached_data.get("checksum")
-            generated_checksum = generate_checksum(value)
-            if generated_checksum != stored_checksum:
-                raise ValueError("Cache integrity check failed.")
+            value = deserialize_cache_entry(cached_data)
             if isinstance(value, dict) and "response_data" in value:
                 return Response(
                     response=value["response_data"],
@@ -124,13 +237,18 @@ class CacheManager:
                     headers=value["headers"],
                 )
             return value
-        except Exception as e:
+        except Exception:
             # Optionally, log the error for debugging
             # print(f"Cache get error: {e}")
             return None
 
     def set(self, key, value, timeout=120):
         """Set data in the cache with a checksum for integrity."""
+        try:
+            self._ensure_backend_available()
+        except CacheBackendUnavailable:
+            return
+
         try:
             if isinstance(value, Response):
                 # Streaming responses should not be cached; forcing them through
@@ -145,20 +263,24 @@ class CacheManager:
                     "status": value.status_code,
                     "headers": minimal_headers,
                 }
-            checksum = generate_checksum(value)
             key = sanitize_cache_key(key)
-            cache_payload = {"value": value, "checksum": checksum}
-            safe_payload = make_orjson_safe(cache_payload)
-            serialized_payload = orjson.dumps(safe_payload, option=orjson.OPT_SORT_KEYS)
+            serialized_payload = serialize_cache_entry(value)
             self.redis_client.setex(key, timeout, serialized_payload)
-        except Exception as e:
-            # Optionally, log the error for debugging
-            # print(f"Cache set error: {e}")
-            pass
+        except RedisError as exc:
+            self._mark_backend_unavailable()
+            logger.warning("Redis cache write failed: %s", exc)
+        except Exception:
+            logger.exception("Cache value serialization failed")
 
     def delete(self, key):
         """Delete data from the cache by key."""
-        self.redis_client.delete(key)
+        self._ensure_backend_available()
+        try:
+            self.redis_client.delete(key)
+        except RedisError as exc:
+            self._mark_backend_unavailable()
+            raise CacheBackendUnavailable("Redis cache delete failed") from exc
+        self._mark_backend_available()
 
 # Initialize a global cache manager
 cache_manager = CacheManager(redis_client)
@@ -195,19 +317,50 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             # Debug: print cache key
             # print(f"[kev_cache] Cache key: {cache_key}")
 
-            cached_data = cache_manager.get(cache_key)
-            if cached_data:
+            try:
+                cached_data = cache_manager.get(cache_key)
+            except CacheBackendUnavailable:
+                # Redis pressure must not become an unbounded MongoDB fallback.
+                return make_response(
+                    {"error": "Cache temporarily unavailable"},
+                    503,
+                )
+            if cached_data is not None:
                 # print(f"[kev_cache] Cache hit for key: {cache_key}")
                 return cached_data
 
-            # print(f"[kev_cache] Cache miss for key: {cache_key}")
-            result = func(*args, **kwargs)
-            # Normalize every Flask-supported return form before serialization so
-            # cache hits preserve the original status, body, and essential headers.
-            response = make_response(result)
-            # Server errors are transient and must not outlive backend recovery.
-            if response.status_code < 500:
-                cache_manager.set(cache_key, response, timeout=timeout)
-            return result
+            with cache_manager.singleflight(cache_key) as acquired:
+                if not acquired:
+                    return make_response(
+                        {"error": "Origin temporarily busy"},
+                        503,
+                    )
+
+                # A concurrent leader may have filled the key while this
+                # request waited, so recheck before calling the origin.
+                try:
+                    cached_data = cache_manager.get(cache_key)
+                except CacheBackendUnavailable:
+                    return make_response(
+                        {"error": "Cache temporarily unavailable"},
+                        503,
+                    )
+                if cached_data is not None:
+                    return cached_data
+
+                try:
+                    result = func(*args, **kwargs)
+                except PyMongoError:
+                    return make_response(
+                        {"error": "Backend temporarily unavailable"},
+                        503,
+                    )
+                # Normalize every Flask-supported return form before serialization
+                # so cache hits preserve status, body, and essential headers.
+                response = make_response(result)
+                # Server errors are transient and must not outlive recovery.
+                if response.status_code < 500:
+                    cache_manager.set(cache_key, response, timeout=timeout)
+                return result
         return wrapper
     return decorator

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -160,13 +160,13 @@ def deserialize_cache_entry(cached_data):
 class CacheManager:
     def __init__(
         self,
-        redis_client,
+        redis_connection,
         circuit_breaker_seconds=None,
         singleflight_wait_seconds=None,
         time_func=None,
     ):
         """Initialize Redis access with a short per-worker failure circuit."""
-        self.redis_client = redis_client
+        self.redis_client = redis_connection
         self.circuit_breaker_seconds = (
             float(os.getenv("CACHE_CIRCUIT_BREAKER_SECONDS", "1"))
             if circuit_breaker_seconds is None

--- a/utils/database.py
+++ b/utils/database.py
@@ -29,11 +29,11 @@ logging_thread.start()
 
 def create_client(uri):
     # Create a new MongoClient object with snappy compression and bounded timeouts
-    max_pool = int(os.getenv("MONGO_MAX_POOL_SIZE", 20))
-    min_pool = int(os.getenv("MONGO_MIN_POOL_SIZE", 0))
-    connect_timeout = int(os.getenv("MONGO_CONNECT_TIMEOUT_MS", 3000))
-    socket_timeout = int(os.getenv("MONGO_SOCKET_TIMEOUT_MS", 10000))
-    wait_queue_timeout = int(os.getenv("MONGO_WAIT_QUEUE_TIMEOUT_MS", 500))
+    max_pool = int(os.getenv("MONGO_MAX_POOL_SIZE", "20"))
+    min_pool = int(os.getenv("MONGO_MIN_POOL_SIZE", "0"))
+    connect_timeout = int(os.getenv("MONGO_CONNECT_TIMEOUT_MS", "3000"))
+    socket_timeout = int(os.getenv("MONGO_SOCKET_TIMEOUT_MS", "10000"))
+    wait_queue_timeout = int(os.getenv("MONGO_WAIT_QUEUE_TIMEOUT_MS", "500"))
     return MongoClient(
         uri,
         maxPoolSize=max_pool,

--- a/utils/database.py
+++ b/utils/database.py
@@ -33,6 +33,7 @@ def create_client(uri):
     min_pool = int(os.getenv("MONGO_MIN_POOL_SIZE", 0))
     connect_timeout = int(os.getenv("MONGO_CONNECT_TIMEOUT_MS", 3000))
     socket_timeout = int(os.getenv("MONGO_SOCKET_TIMEOUT_MS", 10000))
+    wait_queue_timeout = int(os.getenv("MONGO_WAIT_QUEUE_TIMEOUT_MS", 500))
     return MongoClient(
         uri,
         maxPoolSize=max_pool,
@@ -41,6 +42,8 @@ def create_client(uri):
         serverSelectionTimeoutMS=3000,
         connectTimeoutMS=connect_timeout,
         socketTimeoutMS=socket_timeout,
+        # Bound pool checkout latency so overload becomes explicit backpressure.
+        waitQueueTimeoutMS=wait_queue_timeout,
     )
 
 def ensure_connection(client, uri, max_retries=3):


### PR DESCRIPTION
## Summary

Harden KEVin's cache and database paths against burst-driven pool exhaustion without changing the successful response contracts.

## Validated issues and fixes

- **Redis pool exhaustion could surface as a 500:** Redis reads now translate redis-py pool and connection failures into a retryable 503. A one-second per-worker circuit prevents repeated Redis attempts and, critically, prevents cache pain from becoming an unbounded MongoDB fallback.
- **Redis capacity and waits were undersized/unbounded for gevent load:** the client now uses a `BlockingConnectionPool` with a default of 100 connections per worker, a 50 ms checkout wait, and one-second socket/connect timeouts. Existing `MAX_CONNECTIONS` deployments remain compatible; `REDIS_MAX_CONNECTIONS` is the preferred override.
- **Hot manual-cache routes always queried MongoDB:** `cveLandResource` and `VulnerabilityResource` now read Redis synchronously first and admit database work only on a true miss.
- **Cache misses could stampede:** cache-decorated routes and the manual cache paths now use bounded per-key, per-worker singleflight with a double-checked cache read. Waiters either reuse the filled value or receive 503 after the bounded wait.
- **Mongo checkout could wait too long:** `waitQueueTimeoutMS` now defaults to 500 ms, and PyMongo checkout failures become retryable 503 responses.
- **Greenlet submission could block or bypass the pool:** a shared backend admission controller reserves capacity non-blockingly, caps active Mongo tasks at `min(MAX_GREENLETS, MONGO_MAX_POOL_SIZE)` (20 by default), and maps saturation/timeouts to 503/504. Metrics, KEV existence, manual cache misses, and published/modified list queries use this controller.
- **`/kev/recent` streamed an unbounded cursor:** the endpoint preserves its JSON-array response while applying a configurable 500-record server maximum. Clients may request a lower `limit`.
- **Cache-hit checksums reserialized every value:** new cache entries use a versioned binary envelope that hashes the stored JSON bytes directly. Legacy entries remain readable through their current TTL, and tampered entries are still rejected.

The Gunicorn worker count, timeout, and max-request recycling remain unchanged: the supplied configuration was confirmed, but the claimed operational harm was not actionable without deployment telemetry. The exact order of capacity bottlenecks is likewise workload-dependent.

## Validation

- `uv run --python 3.12 --with-requirements requirements.txt python -m pytest -q` — 22 passed
- exact compatibility check — Redis 8.0.1, PyMongo 4.17.0, gevent 26.5.0; Mongo wait queue resolved to 0.5 seconds
- `python -m compileall -q kevin.py schema utils tests` — passed
- change-scoped Ruff fatal checks — passed
- change-scoped Bandit scan — passed
- `git diff --check` — passed

## Remaining operational note

Singleflight is intentionally per worker, so a cold key can still produce up to one fill per Gunicorn worker. Backend admission and Mongo checkout timeouts bound that residual cross-worker load.