### PR TITLE
Filter Codacy quality noise from Code Security

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,11 +36,11 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
@@ -54,8 +54,14 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      # Codacy also reports quality tools such as Pylint and Prospector. Keep
+      # those analyses in Codacy while reserving GitHub Code Security for
+      # production findings emitted by security-focused tools.
+      - name: Filter security SARIF results
+        run: python3 scripts/filter_security_sarif.py results.sarif results.security.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
-          sarif_file: results.sarif
+          sarif_file: results.security.sarif

--- a/scripts/filter_security_sarif.py
+++ b/scripts/filter_security_sarif.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Prepare Codacy SARIF for GitHub's security-focused code scanning view."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+# Codacy reports quality and security tools in one SARIF document. GitHub's
+# Code Security view should receive only tools whose primary purpose is finding
+# production security defects.
+SECURITY_TOOL_PREFIXES = (
+    "bandit",
+    "hadolint",
+    "jacksonlinter",
+    "opengrep",
+    "semgrep",
+    "trivy",
+)
+TEST_DIRECTORY_NAMES = frozenset({"test", "tests"})
+
+
+@dataclass(frozen=True)
+class FilterSummary:
+    """Describe how many SARIF results were retained or removed."""
+
+    retained_results: int = 0
+    removed_test_results: int = 0
+    emptied_quality_results: int = 0
+
+
+def _is_security_tool(tool_name: str) -> bool:
+    """Return whether a Codacy tool belongs in GitHub Code Security."""
+    normalized_name = tool_name.strip().casefold()
+    return normalized_name.startswith(SECURITY_TOOL_PREFIXES)
+
+
+def _artifact_path(location: dict[str, Any]) -> str | None:
+    """Extract and normalize a repository path from one SARIF location."""
+    artifact = (
+        location.get("physicalLocation", {})
+        .get("artifactLocation", {})
+        .get("uri")
+    )
+    if not isinstance(artifact, str) or not artifact:
+        return None
+
+    parsed = urlparse(artifact)
+    path = parsed.path if parsed.scheme else artifact
+    return unquote(path).replace("\\", "/")
+
+
+def _is_test_path(path: str) -> bool:
+    """Return whether a normalized path is contained in a test directory."""
+    parts = PurePosixPath(path).parts
+    return any(part.casefold() in TEST_DIRECTORY_NAMES for part in parts)
+
+
+def _is_test_only_result(result: dict[str, Any]) -> bool:
+    """Return whether every usable location for a result is test-only."""
+    locations = result.get("locations")
+    if not isinstance(locations, list) or not locations:
+        return False
+
+    paths = [_artifact_path(location) for location in locations]
+    # Missing locations are preserved because they may represent a valid
+    # repository-level finding that cannot safely be classified as test-only.
+    if any(path is None for path in paths):
+        return False
+    return all(_is_test_path(path) for path in paths if path is not None)
+
+
+def filter_security_sarif(
+    document: dict[str, Any],
+) -> tuple[dict[str, Any], FilterSummary]:
+    """Return SARIF containing only production findings from security tools."""
+    runs = document.get("runs")
+    if not isinstance(runs, list):
+        raise ValueError("SARIF document must contain a 'runs' list.")
+
+    filtered_document = copy.deepcopy(document)
+    retained_results = 0
+    removed_test_results = 0
+    emptied_quality_results = 0
+
+    for run in filtered_document["runs"]:
+        driver = run.get("tool", {}).get("driver", {})
+        tool_name = driver.get("name", "")
+        results = run.get("results", [])
+        if not isinstance(tool_name, str) or not isinstance(results, list):
+            raise ValueError("Each SARIF run must contain a tool name and results list.")
+
+        if not _is_security_tool(tool_name):
+            # Retaining an empty run lets GitHub supersede and close alerts
+            # previously uploaded for the same quality tool.
+            emptied_quality_results += len(results)
+            run["results"] = []
+            continue
+
+        production_results = []
+        for result in results:
+            if _is_test_only_result(result):
+                removed_test_results += 1
+                continue
+            production_results.append(result)
+
+        run["results"] = production_results
+        retained_results += len(production_results)
+
+    return filtered_document, FilterSummary(
+        retained_results=retained_results,
+        removed_test_results=removed_test_results,
+        emptied_quality_results=emptied_quality_results,
+    )
+
+
+def filter_sarif_file(input_path: Path, output_path: Path) -> FilterSummary:
+    """Read, filter, and write a SARIF document using deterministic JSON."""
+    with input_path.open(encoding="utf-8") as input_file:
+        document = json.load(input_file)
+
+    filtered_document, summary = filter_security_sarif(document)
+    with output_path.open("w", encoding="utf-8") as output_file:
+        json.dump(filtered_document, output_file, indent=2)
+        output_file.write("\n")
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line paths for the input and filtered SARIF documents."""
+    parser = argparse.ArgumentParser(
+        description="Filter Codacy SARIF for GitHub Code Security.",
+    )
+    parser.add_argument("input", type=Path, help="Unfiltered Codacy SARIF file")
+    parser.add_argument("output", type=Path, help="Filtered SARIF output file")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Filter one SARIF file and print a concise workflow summary."""
+    args = _parse_args()
+    summary = filter_sarif_file(args.input, args.output)
+    print(
+        "Security SARIF prepared: "
+        f"{summary.retained_results} retained, "
+        f"{summary.removed_test_results} test-only removed, "
+        f"{summary.emptied_quality_results} quality results omitted."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/filter_security_sarif.py
+++ b/scripts/filter_security_sarif.py
@@ -76,6 +76,123 @@ def _is_test_only_result(result: dict[str, Any]) -> bool:
     return all(_is_test_path(path) for path in paths if path is not None)
 
 
+def _shift_artifact_indices(value: Any, offset: int) -> None:
+    """Shift artifact references recursively after two run tables are joined."""
+    if isinstance(value, dict):
+        artifact_location = value.get("artifactLocation")
+        if isinstance(artifact_location, dict):
+            artifact_index = artifact_location.get("index")
+            if isinstance(artifact_index, int):
+                artifact_location["index"] = artifact_index + offset
+        for nested_value in value.values():
+            _shift_artifact_indices(nested_value, offset)
+    elif isinstance(value, list):
+        for nested_value in value:
+            _shift_artifact_indices(nested_value, offset)
+
+
+def _merge_driver_rules(
+    target_driver: dict[str, Any],
+    source_driver: dict[str, Any],
+) -> dict[str, int]:
+    """Merge rule metadata and return each rule ID's target index."""
+    target_rules = target_driver.setdefault("rules", [])
+    source_rules = source_driver.get("rules", [])
+    if not isinstance(target_rules, list) or not isinstance(source_rules, list):
+        raise ValueError("SARIF tool driver rules must be lists.")
+
+    rule_indices = {
+        rule["id"]: index
+        for index, rule in enumerate(target_rules)
+        if isinstance(rule, dict) and isinstance(rule.get("id"), str)
+    }
+    for rule in source_rules:
+        rule_id = rule.get("id") if isinstance(rule, dict) else None
+        if not isinstance(rule_id, str) or rule_id in rule_indices:
+            continue
+        rule_indices[rule_id] = len(target_rules)
+        target_rules.append(rule)
+    return rule_indices
+
+
+def _result_rule_id(
+    result: dict[str, Any],
+    source_rules: list[Any],
+) -> str | None:
+    """Resolve a result's rule ID from its explicit or indexed reference."""
+    rule_id = result.get("ruleId")
+    if isinstance(rule_id, str):
+        return rule_id
+
+    rule_reference = result.get("rule")
+    if not isinstance(rule_reference, dict):
+        return None
+    if isinstance(rule_reference.get("id"), str):
+        return rule_reference["id"]
+
+    source_index = rule_reference.get("index")
+    if not isinstance(source_index, int) or not 0 <= source_index < len(source_rules):
+        return None
+    source_rule = source_rules[source_index]
+    if not isinstance(source_rule, dict) or not isinstance(source_rule.get("id"), str):
+        return None
+    return source_rule["id"]
+
+
+def _merge_run(target_run: dict[str, Any], source_run: dict[str, Any]) -> None:
+    """Merge one duplicate tool run into its first occurrence."""
+    target_driver = target_run["tool"]["driver"]
+    source_driver = source_run["tool"]["driver"]
+    source_rules = source_driver.get("rules", [])
+    if not isinstance(source_rules, list):
+        raise ValueError("SARIF tool driver rules must be lists.")
+    rule_indices = _merge_driver_rules(target_driver, source_driver)
+
+    target_artifacts = target_run.setdefault("artifacts", [])
+    source_artifacts = source_run.get("artifacts", [])
+    if not isinstance(target_artifacts, list) or not isinstance(source_artifacts, list):
+        raise ValueError("SARIF run artifacts must be lists.")
+    artifact_offset = len(target_artifacts)
+    target_artifacts.extend(source_artifacts)
+
+    # Results from the appended run must point at the newly combined metadata
+    # tables rather than retaining their original zero-based indices.
+    for result in source_run["results"]:
+        _shift_artifact_indices(result, artifact_offset)
+        rule_id = _result_rule_id(result, source_rules)
+        if rule_id in rule_indices:
+            rule_reference = result.setdefault("rule", {})
+            rule_reference["id"] = rule_id
+            rule_reference["index"] = rule_indices[rule_id]
+        target_run["results"].append(result)
+
+
+def _run_category(run: dict[str, Any]) -> str:
+    """Return the analysis category encoded in runAutomationDetails.id."""
+    automation_id = run.get("automationDetails", {}).get("id", "")
+    if not isinstance(automation_id, str) or "/" not in automation_id:
+        return ""
+    return automation_id.rsplit("/", 1)[0]
+
+
+def _coalesce_duplicate_tool_runs(
+    runs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return one run per tool and category while preserving input order."""
+    coalesced_runs = []
+    runs_by_tool = {}
+    for run in runs:
+        tool_name = run["tool"]["driver"]["name"]
+        tool_key = (tool_name.strip().casefold(), _run_category(run))
+        existing_run = runs_by_tool.get(tool_key)
+        if existing_run is None:
+            runs_by_tool[tool_key] = run
+            coalesced_runs.append(run)
+            continue
+        _merge_run(existing_run, run)
+    return coalesced_runs
+
+
 def filter_security_sarif(
     document: dict[str, Any],
 ) -> tuple[dict[str, Any], FilterSummary]:
@@ -113,6 +230,9 @@ def filter_security_sarif(
         run["results"] = production_results
         retained_results += len(production_results)
 
+    filtered_document["runs"] = _coalesce_duplicate_tool_runs(
+        filtered_document["runs"]
+    )
     return filtered_document, FilterSummary(
         retained_results=retained_results,
         removed_test_results=removed_test_results,

--- a/tests/filter_security_sarif_test.py
+++ b/tests/filter_security_sarif_test.py
@@ -1,0 +1,84 @@
+"""Regression tests for the GitHub Code Security SARIF filter."""
+
+from copy import deepcopy
+
+from scripts.filter_security_sarif import filter_security_sarif
+
+
+def _result(path=None):
+    """Build one minimal SARIF result with an optional source location."""
+    result = {"ruleId": "example-rule", "message": {"text": "Example finding"}}
+    if path is not None:
+        result["locations"] = [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": path,
+                    }
+                }
+            }
+        ]
+    return result
+
+
+def _run(tool_name, results):
+    """Build one minimal SARIF run for a named analysis tool."""
+    return {
+        "tool": {"driver": {"name": tool_name}},
+        "results": results,
+    }
+
+
+def test_filter_keeps_production_security_results():
+    """A production finding from a security tool remains uploadable."""
+    document = {"runs": [_run("Bandit (reported by Codacy)", [_result("kevin.py")])]}
+
+    filtered, summary = filter_security_sarif(deepcopy(document))
+
+    assert len(filtered["runs"][0]["results"]) == 1
+    assert summary.retained_results == 1
+    assert summary.removed_test_results == 0
+
+
+def test_filter_removes_test_only_security_results():
+    """A finding located only in tests does not enter Code Security."""
+    document = {
+        "runs": [
+            _run(
+                "Bandit (reported by Codacy)",
+                [_result("tests/security_regression_test.py")],
+            )
+        ]
+    }
+
+    filtered, summary = filter_security_sarif(deepcopy(document))
+
+    assert filtered["runs"][0]["results"] == []
+    assert summary.retained_results == 0
+    assert summary.removed_test_results == 1
+
+
+def test_filter_empties_quality_runs_without_dropping_them():
+    """A replacement empty quality run can close its existing GitHub alerts."""
+    document = {
+        "runs": [
+            _run("Pylintpython3 (reported by Codacy)", [_result("utils/cache.py")])
+        ]
+    }
+
+    filtered, summary = filter_security_sarif(deepcopy(document))
+
+    assert len(filtered["runs"]) == 1
+    assert filtered["runs"][0]["tool"]["driver"]["name"].startswith("Pylint")
+    assert filtered["runs"][0]["results"] == []
+    assert summary.emptied_quality_results == 1
+
+
+def test_filter_keeps_location_free_security_results():
+    """A repository-level security finding is retained when it has no location."""
+    document = {"runs": [_run("Trivy (reported by Codacy)", [_result()])]}
+
+    filtered, summary = filter_security_sarif(deepcopy(document))
+
+    assert len(filtered["runs"][0]["results"]) == 1
+    assert summary.retained_results == 1

--- a/tests/filter_security_sarif_test.py
+++ b/tests/filter_security_sarif_test.py
@@ -5,9 +5,9 @@ from copy import deepcopy
 from scripts.filter_security_sarif import filter_security_sarif
 
 
-def _result(path=None):
+def _result(path=None, rule_id="example-rule"):
     """Build one minimal SARIF result with an optional source location."""
-    result = {"ruleId": "example-rule", "message": {"text": "Example finding"}}
+    result = {"ruleId": rule_id, "message": {"text": "Example finding"}}
     if path is not None:
         result["locations"] = [
             {
@@ -82,3 +82,71 @@ def test_filter_keeps_location_free_security_results():
 
     assert len(filtered["runs"][0]["results"]) == 1
     assert summary.retained_results == 1
+
+
+def test_filter_coalesces_duplicate_runs_from_the_same_tool():
+    """One tool produces one uploadable run even when Codacy invokes it twice."""
+    first_run = _run(
+        "Opengrep (reported by Codacy)",
+        [_result("kevin.py", rule_id="opengrep-first")],
+    )
+    first_run["tool"]["driver"]["rules"] = [{"id": "opengrep-first"}]
+    first_run["artifacts"] = [{"location": {"uri": "kevin.py"}}]
+    first_run["results"][0]["rule"] = {"id": "opengrep-first", "index": 0}
+    first_run["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]["index"] = 0
+
+    second_run = _run(
+        "Opengrep (reported by Codacy)",
+        [_result("schema/api.py", rule_id="opengrep-second")],
+    )
+    second_run["tool"]["driver"]["rules"] = [{"id": "opengrep-second"}]
+    second_run["artifacts"] = [{"location": {"uri": "schema/api.py"}}]
+    second_run["results"][0]["rule"] = {"id": "opengrep-second", "index": 0}
+    second_run["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]["index"] = 0
+
+    document = {
+        "runs": [first_run, second_run]
+    }
+
+    filtered, summary = filter_security_sarif(deepcopy(document))
+
+    assert len(filtered["runs"]) == 1
+    assert [
+        result["ruleId"] for result in filtered["runs"][0]["results"]
+    ] == ["opengrep-first", "opengrep-second"]
+    assert [
+        rule["id"] for rule in filtered["runs"][0]["tool"]["driver"]["rules"]
+    ] == ["opengrep-first", "opengrep-second"]
+    assert [
+        result["rule"]["index"] for result in filtered["runs"][0]["results"]
+    ] == [0, 1]
+    assert [
+        result["locations"][0]["physicalLocation"]["artifactLocation"]["index"]
+        for result in filtered["runs"][0]["results"]
+    ] == [0, 1]
+    assert summary.retained_results == 2
+
+
+def test_filter_preserves_same_tool_runs_with_distinct_categories():
+    """Distinct analysis categories remain independently uploadable."""
+    first_run = _run(
+        "Opengrep (reported by Codacy)",
+        [_result("kevin.py", rule_id="opengrep-python")],
+    )
+    first_run["automationDetails"] = {"id": "codacy/python/"}
+    second_run = _run(
+        "Opengrep (reported by Codacy)",
+        [_result("Dockerfile", rule_id="opengrep-docker")],
+    )
+    second_run["automationDetails"] = {"id": "codacy/docker/"}
+
+    filtered, summary = filter_security_sarif(
+        {"runs": [first_run, second_run]}
+    )
+
+    assert len(filtered["runs"]) == 2
+    assert summary.retained_results == 2


### PR DESCRIPTION
## Summary

- filter Codacy SARIF before uploading it to GitHub Code Security
- retain production findings from security-focused tools
- keep empty quality-tool runs so GitHub can close their existing alerts
- exclude test-only security-tool findings
- coalesce duplicate tool/category runs while preserving SARIF rule and artifact references
- update the pinned checkout, Codacy, and CodeQL upload actions

## Root cause

The Codacy workflow uploads one SARIF document containing both security and quality analysis. GitHub therefore presents Pylint and Prospector maintainability findings alongside security results. Of the 91 currently open alerts, 32 are test-only Bandit assertion warnings and 59 are quality, complexity, formatting, or analyzer-environment warnings. Static triage found no supported security-boundary vulnerability among them.

Codacy can also invoke the same analyzer multiple times. CodeQL Action v4 rejects duplicate runs sharing a tool and analysis category, so the filter coalesces those runs before upload without losing their results or metadata.

## Impact

Codacy still runs its complete analysis. Only the SARIF copy sent to GitHub is filtered, so production Bandit, Hadolint, Jacksonlinter, Opengrep, Semgrep, and Trivy findings remain eligible for Code Security.

The current 91-alert dataset produces:

```text
open_before=91 open_after_filter=0 test_removed=32 quality_omitted=59
```

GitHub will update the main-branch alert state after this is merged and the Codacy workflow completes on `main`.

## Validation

- `env2/bin/python -m pytest -q` — 29 passed
- `env2/bin/python -m compileall -q scripts tests` — passed
- workflow YAML parse — passed
- `git diff --check` — passed
- duplicate tool/category regression reproduced before the fix and passed afterward
- Codacy Security Scan — passed on PR #350
- all per-tool SARIF checks and CodeQL jobs — passed