### PR TITLE
Fix unauthenticated recent-KEV stream resource exhaustion

### DIFF
--- a/schema/api.py
+++ b/schema/api.py
@@ -7,7 +7,7 @@ import os
 import re
 
 from dotenv import load_dotenv
-from flask import Response, json, jsonify, make_response, request, stream_with_context
+from flask import jsonify, make_response, request
 from flask_restful import Resource
 from pymongo import ASCENDING, DESCENDING
 from pymongo.errors import PyMongoError
@@ -22,7 +22,6 @@ from schema.serializers import (
 from utils.backend_capacity import (
     BackendBusyError,
     BackendTimeoutError,
-    MAX_BACKEND_CONCURRENCY,
     run_backend_tasks,
 )
 from utils.cache_manager import (
@@ -49,6 +48,7 @@ MONGO_QUERY_MAX_TIME_MS = max(
     int(os.environ.get("MONGO_QUERY_MAX_TIME_MS", "5000")),
 )
 RECENT_VULNERABILITY_QUERY_PARAMETERS = {"days", "page", "per_page"}
+RECENT_KEV_QUERY_PARAMETERS = {"days", "limit"}
 ALL_KEV_QUERY_PARAMETERS = {
     "actor",
     "filter",
@@ -116,6 +116,40 @@ def canonical_recent_vulnerability_query_items():
         ("days", [str(days)]),
         ("page", [str(page)]),
         ("per_page", [str(per_page)]),
+    ]
+
+
+def parse_recent_kev_query():
+    """Validate and canonicalize the bounded recent-KEV query parameters."""
+    unknown_parameters = sorted(
+        set(request.args.keys()) - RECENT_KEV_QUERY_PARAMETERS
+    )
+    if unknown_parameters:
+        names = ", ".join(unknown_parameters)
+        raise ValueError(f"Unsupported query parameter(s): {names}")
+
+    days = _strict_query_integer("days")
+    result_limit = _strict_query_integer(
+        "limit",
+        default=RECENT_KEV_MAX_RESULTS,
+    )
+
+    if days > 100:
+        raise ValueError("Exceeded the maximum limit of 100 days")
+    if result_limit < 1 or result_limit > RECENT_KEV_MAX_RESULTS:
+        raise ValueError(
+            f"Limit must be between 1 and {RECENT_KEV_MAX_RESULTS} results"
+        )
+
+    return days, result_limit
+
+
+def canonical_recent_kev_query_items():
+    """Return stable cache-key items for one validated recent-KEV query."""
+    days, result_limit = parse_recent_kev_query()
+    return [
+        ("days", [str(days)]),
+        ("limit", [str(result_limit)]),
     ]
 
 
@@ -543,7 +577,11 @@ class AllKevVulnerabilitiesResource(BaseResource):
 
 # Resource for fetching recent vulnerabilities
 class RecentKevVulnerabilitiesResource(BaseResource):
-    @cache(timeout=60, key_prefix='recent_kevs_', query_string=True)
+    @cache(
+        timeout=60,
+        key_prefix="recent_kevs_",
+        query_string=canonical_recent_kev_query_items,
+    )
     def get(self):
         """
         Retrieve recent KEV vulnerabilities added within a specified number of days.
@@ -554,68 +592,47 @@ class RecentKevVulnerabilitiesResource(BaseResource):
 
         Query Parameters:
         - days (int): The number of days to look back for recent vulnerabilities.
-        - limit (int): Maximum records to stream, capped by server configuration.
+        - limit (int): Maximum records to return, capped by server configuration.
 
         Returns:
         Response: A JSON response containing a list of recent vulnerabilities
                   or an error message if the input parameter is invalid.
         """
-        # Get the 'days' parameter from the query string
-        days = request.args.get("days", type=int)
-        # Validate the 'days' parameter
-        if days is None or days < 0:
-            return self.handle_error("Invalid value for days", 400)
-        # Limit days to a maximum of 100
-        if days > 100:
-            return self.handle_error("Exceeded the maximum limit of 100 days", 400)
-        result_limit = request.args.get(
-            "limit",
-            default=RECENT_KEV_MAX_RESULTS,
-            type=int,
-        )
-        if result_limit is None or result_limit < 1:
-            return self.handle_error("Invalid value for limit", 400)
-        if result_limit > RECENT_KEV_MAX_RESULTS:
-            return self.handle_error(
-                f"Exceeded the maximum limit of {RECENT_KEV_MAX_RESULTS} results",
-                400,
-            )
-        # Calculate the cutoff date based on the 'days' parameter
+        # Reuse the cache-key parser so accepted behavior and cache identity
+        # cannot drift apart.
+        days, result_limit = parse_recent_kev_query()
         cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
         cutoff_date_str = cutoff_date.strftime("%Y-%m-%d")
-        
-        # Use server-side filtering - only fetch vulnerabilities with dateAdded >= cutoff_date
-        cursor = collection.find(
-            {"dateAdded": {"$gte": cutoff_date_str}}
-        ).sort("dateAdded", DESCENDING).limit(result_limit)
 
-        # Stream the cursor in manageable batches to avoid loading every
-        # vulnerability into memory at once.
-        batch_size = max(1, min(MAX_BACKEND_CONCURRENCY, 200))
-        cursor = cursor.batch_size(batch_size)
+        try:
+            vulnerabilities = run_backend_tasks(
+                [
+                    partial(
+                        self.query_recent_vulnerabilities,
+                        cutoff_date_str,
+                        result_limit,
+                    )
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )[0]
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
+            return self.handle_error("Upstream timeout", 504)
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
 
-        def stream_vulnerabilities():
-            yield '['
-            first_chunk = True
-            try:
-                for vulnerability in cursor:
-                    serialized = serialize_vulnerability(vulnerability)
-                    payload = json.dumps(serialized, default=str)
-                    if first_chunk:
-                        first_chunk = False
-                    else:
-                        yield ','
-                    yield payload
-            finally:
-                cursor.close()
-            yield ']'
+        return self.make_json_response(vulnerabilities)
 
-        response = Response(
-            stream_with_context(stream_vulnerabilities()),
-            mimetype="application/json"
+    def query_recent_vulnerabilities(self, cutoff_date, result_limit):
+        """Materialize one bounded, deadline-limited query under admission."""
+        cursor = (
+            collection.find({"dateAdded": {"$gte": cutoff_date}})
+            .sort("dateAdded", DESCENDING)
+            .limit(result_limit)
+            .max_time_ms(MONGO_QUERY_MAX_TIME_MS)
         )
-
-        return response
+        return [serialize_vulnerability(vulnerability) for vulnerability in cursor]
 
     def process_vulnerability(self, vulnerability, cutoff_date):
         """Process a single vulnerability to check if it meets the cutoff date."""

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -919,15 +919,14 @@ def test_schema_resources_never_block_in_greenlet_pool_spawn():
     assert source.count("run_backend_tasks(") >= 3
 
 
-def test_recent_kev_stream_applies_requested_bounded_limit(monkeypatch):
-    """The recent KEV cursor is capped before a streaming response begins."""
+def test_recent_kev_query_is_admitted_canonical_bounded_and_cached(monkeypatch):
+    """Recent KEV responses finish bounded backend work before caching."""
 
     class RecordingCursor:
-        """Record cursor bounds without requiring a running MongoDB server."""
+        """Record query bounds and return one representative vulnerability."""
 
         def __init__(self):
             """Initialize a cursor with no configured bound."""
-            self.limit_value = None
             self.operations = []
 
         def sort(self, key, direction):
@@ -936,55 +935,130 @@ def test_recent_kev_stream_applies_requested_bounded_limit(monkeypatch):
             return self
 
         def limit(self, value):
-            """Record and return the maximum number of streamed records."""
-            self.limit_value = value
+            """Record and return the maximum number of materialized records."""
             self.operations.append(("limit", value))
             return self
 
-        def batch_size(self, _value):
-            """Preserve the cursor call chain used by the resource."""
+        def max_time_ms(self, value):
+            """Record and return the MongoDB execution deadline."""
+            self.operations.append(("max_time_ms", value))
             return self
 
-        def close(self):
-            """Match the PyMongo cursor cleanup interface."""
-
         def __iter__(self):
-            """Return an empty iterator because only query shape is tested."""
-            return iter(())
+            """Yield a record that exercises the public serializer."""
+            return iter(
+                [
+                    {
+                        "_id": "record-1",
+                        "cveID": "CVE-2026-0001",
+                        "dateAdded": "2026-01-01",
+                        "dueDate": "2026-01-22",
+                    }
+                ]
+            )
 
     class RecentCollection:
-        """Return the recording cursor for a recent-vulnerability query."""
+        """Record each origin query and its independently configured cursor."""
 
         def __init__(self):
-            """Create one reusable cursor for assertion."""
-            self.cursor = RecordingCursor()
+            """Initialize empty query and cursor logs."""
+            self.find_calls = []
+            self.cursors = []
 
-        def find(self, _query):
-            """Return the cursor that records the applied result cap."""
-            return self.cursor
+        def find(self, query):
+            """Record the filter and return a fresh recording cursor."""
+            cursor = RecordingCursor()
+            self.find_calls.append(query)
+            self.cursors.append(cursor)
+            return cursor
 
     recent_collection = RecentCollection()
     fake_database = types.ModuleType("utils.database")
     fake_database.collection = recent_collection
     fake_database.all_vulns_collection = recent_collection
     monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
     sys.modules.pop("schema.api", None)
 
     try:
         api_module = importlib.import_module("schema.api")
         resource = api_module.RecentKevVulnerabilitiesResource()
         app = Flask(__name__)
-        with app.test_request_context("/kev/recent?days=100&limit=25"):
-            response = resource.get.__wrapped__(resource)
+
+        admitted_requests = []
+        original_run_backend_tasks = api_module.run_backend_tasks
+
+        def recording_run_backend_tasks(tasks, timeout):
+            """Record admission while preserving the production execution path."""
+            admitted_requests.append(timeout)
+            return original_run_backend_tasks(tasks, timeout=timeout)
+
+        monkeypatch.setattr(
+            api_module,
+            "run_backend_tasks",
+            recording_run_backend_tasks,
+        )
+
+        valid_urls = (
+            "/kev/recent?days=007&limit=025",
+            "/kev/recent?limit=25&days=7",
+        )
+        responses = []
+        for url in valid_urls:
+            with app.test_request_context(url):
+                responses.append(resource.get())
+
+        # Omitting the optional limit preserves the documented maximum default.
+        with app.test_request_context("/kev/recent?days=7"):
+            default_limit_response = resource.get()
+
+        cache_get_calls_before_invalid_requests = memory_redis.get_calls
+        invalid_urls = (
+            "/kev/recent?days=7&nonce=1",
+            "/kev/recent?days=7&days=7",
+            "/kev/recent?days=7&limit=25&limit=25",
+            "/kev/recent?days=7!&limit=25",
+            "/kev/recent?days=7&limit=0",
+            f"/kev/recent?days=7&limit={api_module.RECENT_KEV_MAX_RESULTS + 1}",
+        )
+        for url in invalid_urls:
+            with app.test_request_context(url):
+                invalid_response = resource.get()
+            assert invalid_response.status_code == 400
+            assert invalid_response.get_json() == {
+                "message": "Invalid query parameters"
+            }
     finally:
         sys.modules.pop("schema.api", None)
 
-    assert response.status_code == 200
-    assert recent_collection.cursor.limit_value == 25
-    assert recent_collection.cursor.operations == [
+    assert [response.status_code for response in responses] == [200, 200]
+    assert all(not response.is_streamed for response in responses)
+    assert responses[0].get_json() == responses[1].get_json()
+    assert default_limit_response.status_code == 200
+    assert not default_limit_response.is_streamed
+
+    # Equivalent explicit queries share one origin fill; the default is a
+    # separate, legitimate cache identity with its documented result limit.
+    assert len(recent_collection.find_calls) == 2
+    assert len(memory_redis.values) == 2
+    assert admitted_requests == [api_module.GREENLET_TIMEOUT] * 2
+    assert recent_collection.cursors[0].operations == [
         ("sort", "dateAdded", api_module.DESCENDING),
         ("limit", 25),
+        ("max_time_ms", api_module.MONGO_QUERY_MAX_TIME_MS),
     ]
+    assert recent_collection.cursors[1].operations == [
+        ("sort", "dateAdded", api_module.DESCENDING),
+        ("limit", api_module.RECENT_KEV_MAX_RESULTS),
+        ("max_time_ms", api_module.MONGO_QUERY_MAX_TIME_MS),
+    ]
+    assert memory_redis.get_calls == cache_get_calls_before_invalid_requests
 
 
 def test_viz_uses_text_safe_rendering_for_untrusted_api_data():


### PR DESCRIPTION
## Summary

This PR fixes a high-severity availability vulnerability in the intentionally unauthenticated public `/kev/recent` and `/api/kev/recent` endpoints.

Before this change, each request returned a lazy MongoDB cursor-backed streaming response. The generic cache deliberately skipped streamed responses, and its singleflight lock ended as soon as the handler returned—before the cursor was consumed. Concurrent or slow-reading internet clients could therefore accumulate uncached cursor streams outside KEVin's shared backend admission control.

## Security impact

- **Class:** uncontrolled resource consumption / application-layer denial of service
- **CWE:** CWE-400
- **Severity:** High (CVSS 3.1: 7.5, AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)
- **Affected routes:** `/kev/recent`, `/api/kev/recent`
- **Required access:** none; anonymous reads remain intentional
- **Impact:** availability only; no confidentiality or integrity impact was identified

The existing 500-record result cap, indexed date filter, MongoDB pool timeouts, and edge throttling reduced per-request cost, but did not bound the lifetime or concurrency of accumulated streams.

## Root cause

The response-cache/singleflight abstraction protected construction of the Flask `Response`, while the sensitive MongoDB iteration and serialization happened later during client-paced WSGI streaming. Because streamed responses were never cached, even identical requests repeatedly reached the origin.

## What changed

- Strictly validate and canonicalize only the supported `days` and `limit` parameters before Redis, singleflight, or MongoDB access.
- Reject unknown, duplicate, non-decimal, or out-of-range parameters with the existing fixed client-safe 400 response.
- Materialize the bounded query under KEVin's shared `run_backend_tasks` admission control.
- Apply the existing MongoDB `MONGO_QUERY_MAX_TIME_MS` execution deadline.
- Return and cache a finite JSON response, ensuring no MongoDB cursor survives handler return.
- Add regression coverage for cache equivalence, admission, query bounds, default behavior, and pre-origin rejection.

## Compatibility

The successful response remains a JSON array with the same serialized vulnerability objects, ordering, `days` semantics, optional `limit`, and default maximum limit.

Intentional tightening: requests containing previously ignored parameters, duplicate parameters, non-decimal numeric forms, or out-of-range limits now return HTTP 400 instead of creating independent cache identities or silently accepting ambiguous input.

## Validation

Passed:

- `env/bin/pytest -q -p no:cacheprovider tests/security_regression_test.py::test_recent_kev_query_is_admitted_canonical_bounded_and_cached` — **1 passed**
- `env/bin/pytest -q -p no:cacheprovider tests/security_regression_test.py` — **25 passed**
- `env/bin/pytest -q -p no:cacheprovider tests/filter_security_sarif_test.py` — **6 passed**
- `env/bin/python -m compileall -q schema utils tests`
- `git diff --check`
- Signed commit verification with `git verify-commit HEAD`

The complete `pytest` collection still requires a live MongoDB instance because `tests/sanitization_test.py` imports the application and connects during collection. Without MongoDB it stops at the repository's existing `Could not connect to MongoDB after multiple attempts` error; the Mongo-independent security suites above pass.

## Deployment note

Edge rate limiting remains valuable defense in depth. This fix makes the application boundary safe independently by ensuring recent-KEV database work is canonical, deadline-bounded, admitted, finite, and cacheable.