### PR TITLE
Harden unauthenticated API cache and backend admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ Add necessary API KEYS.
 API_KEY=xxx
 MONGODB_URI_PROD=mongodb://MONGO_PROD_IP:27017/
 MONGODB_URI_DEV=mongodb://localhost:27017/
+PUBLIC_BASE_URL=https://kevin.gtfkd.com
+TRUSTED_HOSTS=kevin.gtfkd.com,localhost,127.0.0.1
 ```
 
 Feel free to edit the mongodb in use or variable names. I have both in here since I work on prod and dev mongodbs for the hosted version of KEVin at kevin.gtfkd.com/*.
+
+`PUBLIC_BASE_URL` is the canonical public origin used in homepage metadata.
+`TRUSTED_HOSTS` is a comma-separated allowlist for accepted HTTP Host headers;
+include the hostname used by local health checks and reverse proxies.
 
 **Set up MongoDB:**
 

--- a/kevin.py
+++ b/kevin.py
@@ -24,7 +24,11 @@ from utils.backend_capacity import (
     run_backend_tasks,
 )
 from utils.cache_manager import kev_cache as cache 
-from utils.sanitizer import sanitize_query
+from utils.sanitizer import (
+    canonical_cve_arguments,
+    normalize_cve_id,
+    sanitize_query,
+)
 from utils.rss_feed import create_rss_feed
 from modules.reportgen import report_gen
 from schema.api import (
@@ -47,14 +51,21 @@ logger = logging.getLogger(__name__)
 # Timeout (seconds) for greenlet joins to avoid request hangs
 GREENLET_TIMEOUT = int(os.environ.get("GREENLET_TIMEOUT", "10"))
 
-# Create a cache key for openai routes based on the query parameters
-def cve_cache_key(*args, **kwargs):
-    path = request.path
-    args = str(hash(frozenset(request.args.items())))
-    return path + args
-
 # Load environment variables using python-dotenv
 load_dotenv()
+
+PUBLIC_BASE_URL = os.environ.get(
+    "PUBLIC_BASE_URL",
+    "https://kevin.gtfkd.com",
+).rstrip("/")
+TRUSTED_HOSTS = {
+    host.strip().lower()
+    for host in os.environ.get(
+        "TRUSTED_HOSTS",
+        "kevin.gtfkd.com,localhost,127.0.0.1",
+    ).split(",")
+    if host.strip()
+}
 
 # Initialize the Flask app and the Flask-RESTful API
 app = Flask(__name__)
@@ -70,6 +81,15 @@ compress = Compress(app)
 # Enable CORS for all routes
 CORS(app)
 
+
+@app.before_request
+def reject_untrusted_host():
+    """Reject request authorities outside the deployment's host allowlist."""
+    hostname = request.host.partition(":")[0].lower()
+    if hostname not in TRUSTED_HOSTS:
+        return jsonify({"error": "Untrusted Host header"}), 400
+    return None
+
 # Route for the root endpoint ("/")
 @app.route("/")
 @cache(timeout=1800) # 30 minute cache for the main route.
@@ -81,7 +101,7 @@ def index():
     rendered HTML content. The response is cached for 30 minutes to
     reduce server load.
     """
-    return render_template("index.html")
+    return render_template("index.html", public_base_url=PUBLIC_BASE_URL)
 
 @app.route('/robots.txt')
 # 1 hour cache.
@@ -248,10 +268,38 @@ def get_metrics():
     # Return the metrics as a JSON response
     return jsonify(metrics)
 
+def parse_cve_query():
+    """Return one validated CVE query and reject duplicates or extra fields."""
+    if set(request.args.keys()) != {"cve"}:
+        raise ValueError("Exactly one CVE query parameter is required")
+    cve_values = request.args.getlist("cve")
+    if len(cve_values) != 1:
+        raise ValueError("Duplicate CVE query parameters are not allowed")
+    return normalize_cve_id(cve_values[0])
+
+
+def canonical_cve_query_items():
+    """Return validated CVE query items for stable public cache identity."""
+    return [("cve", [parse_cve_query()])]
+
+
+def lookup_one(database_collection, query):
+    """Run one MongoDB point lookup through shared backend admission."""
+    return run_backend_tasks(
+        [lambda: database_collection.find_one(query)],
+        timeout=GREENLET_TIMEOUT,
+    )[0]
+
+
 # Route to check if a specific CVE ID exists in the KEV database collection
 # Example usage: /kev/exists?cve=CVE-2021-1234
 @app.route("/kev/exists", methods=["GET"])
-@cache(timeout=15, key_prefix='cve_exist', query_string=True) # 15 second cache for the cve_exist route.
+@cache(
+    timeout=15,
+    key_prefix="cve_exist",
+    query_string=canonical_cve_query_items,
+    include_path=False,
+)
 def cve_exist():
     """
     Check if a specific CVE ID exists in the KEV database.
@@ -268,23 +316,10 @@ def cve_exist():
     Response: A JSON response indicating whether the CVE ID exists in the
               KEV database. Returns a 400 error if the CVE ID is not provided.
     """
-    # Extract the 'cve' query parameter from the URL
-    cve_id = request.args.get('cve')
-    # If the 'cve' query parameter is not provided, return an error message
-    if not cve_id:
-        return jsonify({"message": "CVE ID is required as a query parameter."}), 400
-    # Sanitize the input CVE ID to prevent SQL injection attacks
-    sanitized_cve_id = sanitize_query(cve_id)
-
-    # Use Gevent to spawn a greenlet for the database query
-    def fetch_vulnerability():
-        return collection.find_one({"cveID": sanitized_cve_id})
+    sanitized_cve_id = parse_cve_query()
 
     try:
-        vulnerability = run_backend_tasks(
-            [fetch_vulnerability],
-            timeout=GREENLET_TIMEOUT,
-        )[0]
+        vulnerability = lookup_one(collection, {"cveID": sanitized_cve_id})
     except BackendBusyError:
         return jsonify({"error": "Backend busy"}), 503
     except BackendTimeoutError:
@@ -301,7 +336,11 @@ def cve_exist():
 
 # Route for generating a report for a specific vulnerability
 @app.route("/vuln/<string:cve_id>/report", methods=["GET"])
-@cache() # Use the default 10 minute cache for the report route.
+@cache(
+    key_prefix="vulnerability_report",
+    canonical_args=canonical_cve_arguments,
+    include_path=False,
+)
 def vulnerability_report(cve_id):
     """
     Generate a report for a specific vulnerability identified by its CVE ID.
@@ -319,10 +358,18 @@ def vulnerability_report(cve_id):
     Response: Renders the vulnerability report template if the vulnerability is found,
               or returns a 404 error message if the vulnerability is not found.
     """
-    # Sanitize the input CVE ID to prevent SQL injection attacks
-    sanitized_cve_id = sanitize_query(cve_id)
-    # Use the sanitized CVE ID to fetch the corresponding vulnerability from the database
-    vulnerability = all_vulns_collection.find_one({"_id": sanitized_cve_id})
+    sanitized_cve_id = normalize_cve_id(cve_id)
+    try:
+        vulnerability = lookup_one(
+            all_vulns_collection,
+            {"_id": sanitized_cve_id},
+        )
+    except BackendBusyError:
+        return jsonify({"error": "Backend busy"}), 503
+    except BackendTimeoutError:
+        return jsonify({"error": "Backend timeout"}), 504
+    except PyMongoError:
+        return jsonify({"error": "Backend unavailable"}), 503
     # If the vulnerability is found
     if vulnerability:
         # Send the vulnerability data to the reportgen library to generate the report
@@ -357,7 +404,12 @@ def not_found(e):
 
 # OpenAI route for a specific vulnerability with cve parameter
 @app.route("/openai/kev")
-@cache(timeout=10, key_prefix=cve_cache_key) # 10 second cache for the openai route.
+@cache(
+    timeout=10,
+    key_prefix="openai_kev",
+    query_string=canonical_cve_query_items,
+    include_path=False,
+)
 def openai_kev():
     """
     Retrieve KEV vulnerability data for a specific CVE ID from the database.
@@ -376,15 +428,15 @@ def openai_kev():
               or an error message if the CVE ID is missing or the vulnerability
               is not found.
     """
-    # Extract the 'cve' query parameter from the URL
-    cve_id = request.args.get('cve')
-    # If the 'cve' query parameter is not provided, return an error message
-    if not cve_id:
-        return {"message": "CVE ID is required as a query parameter."}, 400
-    # Sanitize the input CVE ID to prevent SQL injection attacks
-    sanitized_cve_id = sanitize_query(cve_id)
-    # Use the sanitized CVE ID to fetch the corresponding vulnerability from the database
-    vulnerability = collection.find_one({"cveID": sanitized_cve_id})
+    sanitized_cve_id = parse_cve_query()
+    try:
+        vulnerability = lookup_one(collection, {"cveID": sanitized_cve_id})
+    except BackendBusyError:
+        return {"error": "Backend busy"}, 503
+    except BackendTimeoutError:
+        return {"error": "Backend timeout"}, 504
+    except PyMongoError:
+        return {"error": "Backend unavailable"}, 503
     # If the vulnerability is found, serialize it and return it as a JSON response
     if vulnerability:
         data = serialize_vulnerability(vulnerability)
@@ -398,7 +450,12 @@ def openai_kev():
     
 # OpenAI route for all vulnerabilities with cve parameter
 @app.route("/openai/vuln")
-@cache(timeout=10, key_prefix=cve_cache_key) # 10 second cache for the openai route.
+@cache(
+    timeout=10,
+    key_prefix="openai_vuln",
+    query_string=canonical_cve_query_items,
+    include_path=False,
+)
 def openai_vuln():
     """
     Retrieve vulnerability data for a specific CVE ID from the database.
@@ -417,15 +474,18 @@ def openai_vuln():
               or an error message if the CVE ID is missing or the vulnerability
               is not found.
     """
-    # Extract the 'cve' query parameter from the URL
-    cve_id = request.args.get('cve')
-    # If the 'cve' query parameter is not provided, return an error message
-    if not cve_id:
-        return {"message": "CVE ID is required as a query parameter."}, 400
-    # Sanitize the input CVE ID to prevent SQL injection attacks
-    sanitized_cve_id = sanitize_query(cve_id)
-    # Use the sanitized CVE ID to fetch the corresponding vulnerability from the database
-    vulnerability = all_vulns_collection.find_one({"_id": sanitized_cve_id})
+    sanitized_cve_id = parse_cve_query()
+    try:
+        vulnerability = lookup_one(
+            all_vulns_collection,
+            {"_id": sanitized_cve_id},
+        )
+    except BackendBusyError:
+        return {"error": "Backend busy"}, 503
+    except BackendTimeoutError:
+        return {"error": "Backend timeout"}, 504
+    except PyMongoError:
+        return {"error": "Backend unavailable"}, 503
     # If the vulnerability is found, serialize it and return it as a JSON response
     if vulnerability:
         data = serialize_all_vulnerability(vulnerability)

--- a/schema/api.py
+++ b/schema/api.py
@@ -43,6 +43,7 @@ RECENT_KEV_MAX_RESULTS = max(
     1,
     int(os.environ.get("RECENT_KEV_MAX_RESULTS", "500")),
 )
+RECENT_KEV_CACHE_TIMEOUT = 60
 MONGO_QUERY_MAX_TIME_MS = max(
     100,
     int(os.environ.get("MONGO_QUERY_MAX_TIME_MS", "5000")),
@@ -61,6 +62,11 @@ ALL_KEV_QUERY_PARAMETERS = {
 
 # Timeout in seconds for admitted backend work to finish.
 GREENLET_TIMEOUT = max(1, int(os.environ.get('GREENLET_TIMEOUT', "10")))
+
+
+class RecentKevCacheFillBusy(RuntimeError):
+    """Signal that another request owns the canonical recent-KEV fill."""
+
 
 def validate_page(page):
     """Reject non-positive and unbounded pages before MongoDB skip() calls."""
@@ -144,13 +150,9 @@ def parse_recent_kev_query():
     return days, result_limit
 
 
-def canonical_recent_kev_query_items():
-    """Return stable cache-key items for one validated recent-KEV query."""
-    days, result_limit = parse_recent_kev_query()
-    return [
-        ("days", [str(days)]),
-        ("limit", [str(result_limit)]),
-    ]
+def recent_kev_cache_key(days):
+    """Return one alias-independent key for a maximum-size daily dataset."""
+    return f"recent_kevs_days_{days}_max_{RECENT_KEV_MAX_RESULTS}"
 
 
 def parse_all_kev_query():
@@ -577,11 +579,6 @@ class AllKevVulnerabilitiesResource(BaseResource):
 
 # Resource for fetching recent vulnerabilities
 class RecentKevVulnerabilitiesResource(BaseResource):
-    @cache(
-        timeout=60,
-        key_prefix="recent_kevs_",
-        query_string=canonical_recent_kev_query_items,
-    )
     def get(self):
         """
         Retrieve recent KEV vulnerabilities added within a specified number of days.
@@ -598,23 +595,23 @@ class RecentKevVulnerabilitiesResource(BaseResource):
         Response: A JSON response containing a list of recent vulnerabilities
                   or an error message if the input parameter is invalid.
         """
-        # Reuse the cache-key parser so accepted behavior and cache identity
-        # cannot drift apart.
-        days, result_limit = parse_recent_kev_query()
-        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
-        cutoff_date_str = cutoff_date.strftime("%Y-%m-%d")
+        try:
+            days, result_limit = parse_recent_kev_query()
+        except ValueError:
+            return self.handle_error("Invalid query parameters", 400)
 
         try:
-            vulnerabilities = run_backend_tasks(
-                [
-                    partial(
-                        self.query_recent_vulnerabilities,
-                        cutoff_date_str,
-                        result_limit,
-                    )
-                ],
-                timeout=GREENLET_TIMEOUT,
-            )[0]
+            vulnerabilities = self.load_recent_vulnerabilities(days)
+        except CacheBackendUnavailable:
+            return make_response(
+                {"error": "Cache temporarily unavailable"},
+                503,
+            )
+        except RecentKevCacheFillBusy:
+            return make_response(
+                {"error": "Origin temporarily busy"},
+                503,
+            )
         except BackendBusyError:
             return self.handle_error("Backend busy", 503)
         except BackendTimeoutError:
@@ -622,7 +619,45 @@ class RecentKevVulnerabilitiesResource(BaseResource):
         except PyMongoError:
             return self.handle_error("Backend unavailable", 503)
 
-        return self.make_json_response(vulnerabilities)
+        # The cached maximum-size dataset is safe to reuse for every requested
+        # prefix, including both public aliases and their trailing-slash forms.
+        return self.make_json_response(vulnerabilities[:result_limit])
+
+    def load_recent_vulnerabilities(self, days):
+        """Load or fill one maximum-size cached dataset for the day window."""
+        cache_key = recent_kev_cache_key(days)
+        cached_vulnerabilities = cache_manager.get(cache_key)
+        if cached_vulnerabilities is not None:
+            return cached_vulnerabilities
+
+        with cache_manager.singleflight(cache_key) as acquired:
+            if not acquired:
+                raise RecentKevCacheFillBusy(
+                    "Recent KEV cache fill already in progress"
+                )
+
+            cached_vulnerabilities = cache_manager.get(cache_key)
+            if cached_vulnerabilities is not None:
+                return cached_vulnerabilities
+
+            cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
+            cutoff_date_str = cutoff_date.strftime("%Y-%m-%d")
+            vulnerabilities = run_backend_tasks(
+                [
+                    partial(
+                        self.query_recent_vulnerabilities,
+                        cutoff_date_str,
+                        RECENT_KEV_MAX_RESULTS,
+                    )
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )[0]
+            cache_manager.set(
+                cache_key,
+                vulnerabilities,
+                timeout=RECENT_KEV_CACHE_TIMEOUT,
+            )
+            return vulnerabilities
 
     def query_recent_vulnerabilities(self, cutoff_date, result_limit):
         """Materialize one bounded, deadline-limited query under admission."""

--- a/schema/api.py
+++ b/schema/api.py
@@ -30,7 +30,11 @@ from utils.cache_manager import (
     kev_cache as cache,
 )
 from utils.database import all_vulns_collection, collection
-from utils.sanitizer import sanitize_query
+from utils.sanitizer import (
+    canonical_cve_arguments,
+    normalize_cve_id,
+    sanitize_query,
+)
 
 # Load env using python-dotenv
 load_dotenv()
@@ -235,6 +239,34 @@ def canonical_all_kev_query_items():
         for name, value in zip(parameter_names, query_values, strict=True)
     ]
 
+
+def _canonical_query_mapping(query_items):
+    """Convert canonical cache items into a scalar policy mapping."""
+    return {name: values[0] for name, values in query_items or []}
+
+
+def should_cache_all_kev(query_items):
+    """Cache only bounded, index-friendly KEV list variants."""
+    query = _canonical_query_mapping(query_items)
+    return (
+        int(query["page"]) <= 10
+        and int(query["per_page"]) == 25
+        and not query["search"]
+        and not query["actor"]
+    )
+
+
+def should_cache_recent_vulnerabilities(query_items):
+    """Cache only the default first page for each bounded day window."""
+    query = _canonical_query_mapping(query_items)
+    return int(query["page"]) == 1 and int(query["per_page"]) == 25
+
+
+def recent_vulnerability_cache_prefix(resource):
+    """Separate published and modified datasets while sharing route aliases."""
+    return f"recent_{resource.query_type}_vulnerabilities"
+
+
 class BaseResource(Resource):
     def handle_error(self, message, status=404):
         response = {"message": message}
@@ -321,9 +353,14 @@ class cveLandResource(BaseResource):
         """ Generate a unique cache key including the CVE ID. """
         return f"cve_data_{cve_id}"
 
+
 # Resource for NVD data from the cveland via CVE-ID, which is the _id field in the cveland collection
 class cveNVDResource(BaseResource):
-    @cache()
+    @cache(
+        key_prefix="cve_nvd",
+        canonical_args=canonical_cve_arguments,
+        include_path=False,
+    )
     def get(self, cve_id):
         """
         Retrieve NVD data for a specific CVE ID.
@@ -340,21 +377,37 @@ class cveNVDResource(BaseResource):
         Response: A JSON response containing the serialized NVD data or an
                   error message if the vulnerability is not found.
         """
-        # Sanitize the input CVE ID
-        sanitized_cve_id = sanitize_query(cve_id)
-        if sanitized_cve_id is None:
-            return self.handle_error("Invalid CVE ID", 400)
-        vulnerability = all_vulns_collection.find_one({"_id": sanitized_cve_id})
+        sanitized_cve_id = normalize_cve_id(cve_id)
+        try:
+            vulnerability = run_backend_tasks(
+                [
+                    lambda: all_vulns_collection.find_one(
+                        {"_id": sanitized_cve_id}
+                    )
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )[0]
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
+            return self.handle_error("Upstream timeout", 504)
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
         if not vulnerability:
             return self.handle_error("Vulnerability not found")
 
         data = nvd_serializer(vulnerability)
         return self.make_json_response(data)
 
-        
+
+
 # This class defines a resource for fetching Mitre data for a specific CVE-ID from the 'cveland' collection
 class cveMitreResource(BaseResource):
-    @cache()  # Use caching to improve performance
+    @cache(
+        key_prefix="cve_mitre",
+        canonical_args=canonical_cve_arguments,
+        include_path=False,
+    )
     def get(self, cve_id):
         """
         Retrieve Mitre data for a specific CVE ID.
@@ -371,12 +424,22 @@ class cveMitreResource(BaseResource):
         Response: A JSON response containing the serialized Mitre data or an
                   error message if the vulnerability is not found.
         """
-        # Sanitize the input CVE ID to prevent injection attacks
-        sanitized_cve_id = sanitize_query(cve_id)
-        if sanitized_cve_id is None:
-            return self.handle_error("Invalid CVE ID", 400)
-        # Fetch the vulnerability with the sanitized CVE ID from the 'all_vulns_collection'
-        vulnerability = all_vulns_collection.find_one({"_id": sanitized_cve_id})
+        sanitized_cve_id = normalize_cve_id(cve_id)
+        try:
+            vulnerability = run_backend_tasks(
+                [
+                    lambda: all_vulns_collection.find_one(
+                        {"_id": sanitized_cve_id}
+                    )
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )[0]
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
+            return self.handle_error("Upstream timeout", 504)
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
         if not vulnerability:
             # If the vulnerability is not found, return a 404 error with a message
             return self.handle_error("Vulnerability not found")
@@ -384,7 +447,8 @@ class cveMitreResource(BaseResource):
         data = mitre_serializer(vulnerability)
         # Return the JSON response with the serialized data
         return self.make_json_response(data)
-    
+
+
 # Resource for fetching a specific vulnerability by CVE ID
 class VulnerabilityResource(BaseResource):
     def get(self, cve_id):
@@ -419,56 +483,48 @@ class VulnerabilityResource(BaseResource):
         references_arg = sanitize_query(references_raw)
         if references_raw is not None and references_arg is None:
             return self.handle_error("Invalid value for references parameter", 400)
-        # Check if the user has requested for PoCs
-        if references_arg == 'pocs':
-            # Bypass the cache and call the serialize_githubpocs function
-            vulnerability = collection.find_one({"cveID": sanitized_cve_id})
-            if not vulnerability:
-                return self.handle_error("Vulnerability not found")
-            data = serialize_githubpocs(vulnerability)
-        elif references_arg != "pocs" and references_arg is not None:
+        if references_arg != "pocs" and references_arg is not None:
             return self.handle_error("Invalid value for references parameter", 400)
+        try:
+            vulnerability = self.load_vulnerability(sanitized_cve_id)
+        except CacheBackendUnavailable:
+            return self.handle_error("Cache temporarily unavailable", 503)
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
+            return self.handle_error("Upstream timeout", 504)
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
+
+        if not vulnerability:
+            return self.handle_error("Vulnerability not found")
+        if references_arg == "pocs":
+            data = serialize_githubpocs(vulnerability)
         else:
-            try:
-                cached_data = self.get_cached_data(sanitized_cve_id)
-            except CacheBackendUnavailable:
-                return self.handle_error("Cache temporarily unavailable", 503)
-            if cached_data is not None:
-                data = serialize_vulnerability(cached_data)
-            else:
-                with cache_manager.singleflight(sanitized_cve_id) as acquired:
-                    if not acquired:
-                        return self.handle_error("Backend busy", 503)
-
-                    try:
-                        cached_data = cache_manager.get(sanitized_cve_id)
-                    except CacheBackendUnavailable:
-                        return self.handle_error("Cache temporarily unavailable", 503)
-                    if cached_data is not None:
-                        data = serialize_vulnerability(cached_data)
-                    else:
-                        try:
-                            vulnerability = run_backend_tasks(
-                                [
-                                    partial(
-                                        self.query_vulnerability,
-                                        sanitized_cve_id,
-                                    )
-                                ],
-                                timeout=GREENLET_TIMEOUT,
-                            )[0]
-                        except BackendBusyError:
-                            return self.handle_error("Backend busy", 503)
-                        except BackendTimeoutError:
-                            return self.handle_error("Upstream timeout", 504)
-                        except PyMongoError:
-                            return self.handle_error("Backend unavailable", 503)
-
-                        if not vulnerability:
-                            return self.handle_error("Vulnerability not found")
-                        cache_manager.set(sanitized_cve_id, vulnerability)
-                        data = serialize_vulnerability(vulnerability)
+            data = serialize_vulnerability(vulnerability)
         return self.make_json_response(data)
+
+    def load_vulnerability(self, sanitized_cve_id):
+        """Load one shared cached record for normal and PoC representations."""
+        cached_data = self.get_cached_data(sanitized_cve_id)
+        if cached_data is not None:
+            return cached_data
+
+        with cache_manager.singleflight(sanitized_cve_id) as acquired:
+            if not acquired:
+                raise BackendBusyError("CVE cache fill already in progress")
+
+            cached_data = cache_manager.get(sanitized_cve_id)
+            if cached_data is not None:
+                return cached_data
+
+            vulnerability = run_backend_tasks(
+                [partial(self.query_vulnerability, sanitized_cve_id)],
+                timeout=GREENLET_TIMEOUT,
+            )[0]
+            if vulnerability:
+                cache_manager.set(sanitized_cve_id, vulnerability)
+            return vulnerability
 
     def get_cached_data(self, sanitized_cve_id):
         """Fetch cached data."""
@@ -484,6 +540,8 @@ class AllKevVulnerabilitiesResource(BaseResource):
         timeout=120,
         key_prefix="all_kev_vulns",
         query_string=canonical_all_kev_query_items,
+        include_path=False,
+        cache_if=should_cache_all_kev,
     )
     def get(self):
         """
@@ -507,75 +565,96 @@ class AllKevVulnerabilitiesResource(BaseResource):
         Response: A JSON response containing pagination info and a list of
                   vulnerabilities, or an error message if an internal error occurs.
         """
+        (
+            page,
+            per_page,
+            sort_param,
+            order_param,
+            search_query,
+            filter_ransomware,
+            actor_query,
+        ) = parse_all_kev_query()
+
+        query = {}
+        if search_query:
+            # Escape special characters in the search term even if it is
+            # already sanitized.
+            search_term = re.escape(search_query)
+            query["vendorProject"] = {"$regex": search_term, "$options": "i"}
+        if filter_ransomware:
+            query["knownRansomwareCampaignUse"] = "Known"
+        if actor_query:
+            query["$or"] = [
+                {
+                    "openThreatData.communityAdversaries": {
+                        "$regex": actor_query,
+                        "$options": "i",
+                    }
+                },
+                {
+                    "openThreatData.adversaries": {
+                        "$regex": actor_query,
+                        "$options": "i",
+                    }
+                },
+            ]
+
+        sort_order = DESCENDING if order_param == "desc" else ASCENDING
+        sort_criteria = [(sort_param, sort_order)]
+
         try:
-            (
-                page,
-                per_page,
-                sort_param,
-                order_param,
-                search_query,
-                filter_ransomware,
-                actor_query,
-            ) = parse_all_kev_query()
+            total_vulns, vulnerabilities = run_backend_tasks(
+                [
+                    partial(self.count_documents, query),
+                    partial(
+                        self.fetch_vulnerabilities,
+                        query,
+                        sort_criteria,
+                        page,
+                        per_page,
+                    ),
+                ],
+                timeout=GREENLET_TIMEOUT,
+            )
+        except BackendBusyError:
+            return self.handle_error("Backend busy", 503)
+        except BackendTimeoutError:
+            return self.handle_error("Upstream timeout", 504)
+        except PyMongoError:
+            return self.handle_error("Backend unavailable", 503)
 
-            query = {}
-            if search_query:
-                # Escape special characters in the search term even if it's already sanitized.
-                search_term = re.escape(search_query)
-                # Only search in the vendorProject field
-                query["vendorProject"] = {"$regex": search_term, "$options": "i"}
-            if filter_ransomware:
-                query["knownRansomwareCampaignUse"] = "Known"
-            if actor_query:
-                # Fuzzy match for actor search
-                actor_query = {"$or": [
-                    {"openThreatData.communityAdversaries": {"$regex": actor_query, "$options": "i"}},
-                    {"openThreatData.adversaries": {"$regex": actor_query, "$options": "i"}}
-                ]}
-                query.update(actor_query)  # Merge actor query into the main query
+        total_pages = math.ceil(total_vulns / per_page)
 
-            sort_order = DESCENDING if order_param == "desc" else ASCENDING
-            sort_criteria = [(sort_param, sort_order)]
-
-            # Always run the query - caching is now handled at the method level
-            total_vulns = self.count_documents(query)
-            vulnerabilities = self.fetch_vulnerabilities(query, sort_criteria, page, per_page)
-
-            total_pages = math.ceil(total_vulns / per_page)
-
-            return self.make_json_response({
+        return self.make_json_response(
+            {
                 "page": page,
                 "per_page": per_page,
                 "total_vulns": total_vulns,
                 "total_pages": total_pages,
-                "vulnerabilities": [serialize_vulnerability(v) for v in vulnerabilities]
-            })
-        except Exception:
-            return self.handle_error("An internal server error occurred! ", 500)
+                "vulnerabilities": [
+                    serialize_vulnerability(vulnerability)
+                    for vulnerability in vulnerabilities
+                ],
+            }
+        )
 
     def count_documents(self, query):
         """Count the total number of vulnerabilities matching the query."""
-        try:
-            return collection.count_documents(
-                query,
-                maxTimeMS=MONGO_QUERY_MAX_TIME_MS,
-            )
-        except Exception as e:
-            raise e
+        return collection.count_documents(
+            query,
+            maxTimeMS=MONGO_QUERY_MAX_TIME_MS,
+        )
 
     def fetch_vulnerabilities(self, query, sort_criteria, page, per_page):
         """Fetch vulnerabilities from the database."""
-        try:
-            cursor = (
-                collection.find(query)
-                .sort(sort_criteria)
-                .skip((page - 1) * per_page)
-                .limit(per_page)
-                .max_time_ms(MONGO_QUERY_MAX_TIME_MS)
-            )
-            return list(cursor)  # Return cursor as a list
-        except Exception as e:
-            raise e
+        cursor = (
+            collection.find(query)
+            .sort(sort_criteria)
+            .skip((page - 1) * per_page)
+            .limit(per_page)
+            .max_time_ms(MONGO_QUERY_MAX_TIME_MS)
+        )
+        return list(cursor)
 
 # Resource for fetching recent vulnerabilities
 class RecentKevVulnerabilitiesResource(BaseResource):
@@ -688,8 +767,10 @@ class RecentVulnerabilitiesByDaysResource(BaseResource):
 
     @cache(
         timeout=600,
-        key_prefix="recent_days_vulnerabilities",
+        key_prefix=recent_vulnerability_cache_prefix,
         query_string=canonical_recent_vulnerability_query_items,
+        include_path=False,
+        cache_if=should_cache_recent_vulnerabilities,
     )
     def get(self):
         """

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,22 +6,22 @@
     <meta charset="UTF-8">
     <meta name="description"
         content="Access CISA's Known Exploited Vulnerabilities Catalog (KEV) and CVE Data through the KEVin API.">
-    <link rel="canonical" href="{{ url_for('index', _external=True) }}">
+    <link rel="canonical" href="{{ public_base_url }}/">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#0b0f17">
     <meta property="og:title" content="KEVin Vulnerability API">
     <meta property="og:description"
         content="Access CISA's Known Exploited Vulnerabilities Catalog (KEV) and CVE Data through the KEVin API.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ url_for('index', _external=True) }}">
-    <meta property="og:image" content="{{ url_for('static', filename='android-chrome-512x512.png', _external=True) }}">
+    <meta property="og:url" content="{{ public_base_url }}/">
+    <meta property="og:image" content="{{ public_base_url }}{{ url_for('static', filename='android-chrome-512x512.png') }}">
     <meta property="og:image:alt" content="KEVin API logo">
     <meta property="og:site_name" content="KEVin API">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="KEVin Vulnerability API">
     <meta name="twitter:description"
         content="Access CISA's Known Exploited Vulnerabilities Catalog (KEV) and CVE Data through the KEVin API.">
-    <meta name="twitter:image" content="{{ url_for('static', filename='android-chrome-512x512.png', _external=True) }}">
+    <meta name="twitter:image" content="{{ public_base_url }}{{ url_for('static', filename='android-chrome-512x512.png') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='apple-touch-icon.png') }}"
         alt="Apple Touch Icon">
@@ -38,7 +38,7 @@
             "@context": "https://schema.org",
             "@type": "WebSite",
             "name": "KEVin Vulnerability API",
-            "url": "{{ url_for('index', _external=True) }}",
+            "url": "{{ public_base_url }}/",
             "description": "Access CISA's Known Exploited Vulnerabilities Catalog (KEV) and CVE Data through the KEVin API."
         }
     </script>

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -158,6 +158,52 @@ def test_cache_query_validation_does_not_expose_exception_details(monkeypatch):
     assert b"secret-field" not in response.get_data()
 
 
+def test_cache_canonical_arguments_share_aliases_before_origin(monkeypatch):
+    """Canonical path arguments collapse aliases before cache or singleflight."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+    origin_calls = []
+
+    def canonical_cve_arguments(cve_id):
+        """Normalize representative CVE path spellings or reject invalid input."""
+        normalized = cve_id.replace("!", "").upper()
+        if not normalized.startswith("CVE-"):
+            raise ValueError("invalid CVE")
+        return (normalized,)
+
+    @cache_module.kev_cache(
+        key_prefix="canonical_cve",
+        canonical_args=canonical_cve_arguments,
+        include_path=False,
+    )
+    def cached_lookup(cve_id):
+        """Record the origin spelling while returning equivalent data."""
+        origin_calls.append(cve_id)
+        return {"cve": cve_id.replace("!", "").upper()}
+
+    app = Flask(__name__)
+    with app.test_request_context("/vuln/cve-2026-0001/nvd"):
+        first_response = cached_lookup("cve-2026-0001")
+    with app.test_request_context("/api/vuln/CVE-2026-0001!/nvd/"):
+        alias_response = cached_lookup("CVE-2026-0001!")
+    cache_get_calls_before_invalid = memory_redis.get_calls
+    with app.test_request_context("/vuln/not-a-cve/nvd"):
+        invalid_response = cached_lookup("not-a-cve")
+
+    assert first_response == {"cve": "CVE-2026-0001"}
+    assert alias_response.get_json() == first_response
+    assert origin_calls == ["cve-2026-0001"]
+    assert len(memory_redis.values) == 1
+    assert invalid_response.status_code == 400
+    assert memory_redis.get_calls == cache_get_calls_before_invalid
+
+
 def test_recent_vulnerability_cache_uses_canonical_validated_query(monkeypatch):
     """Equivalent requests share one fill and invalid keys never reach MongoDB."""
 
@@ -260,6 +306,15 @@ def test_recent_vulnerability_cache_uses_canonical_validated_query(monkeypatch):
                 with app.test_request_context(url):
                     response = resource.get()
                 assert response.status_code == 200
+
+        noncacheable_requests = (
+            (published, "/vuln/published?days=30&page=2&per_page=25"),
+            (modified, "/api/vuln/modified?days=30&page=1&per_page=100"),
+        )
+        for resource, url in noncacheable_requests:
+            with app.test_request_context(url):
+                response = resource.get()
+            assert response.status_code == 200
         valid_cache_get_calls = memory_redis.get_calls
 
         invalid_requests = (
@@ -279,6 +334,7 @@ def test_recent_vulnerability_cache_uses_canonical_validated_query(monkeypatch):
 
     assert len(recent_collection.count_calls) == 4
     assert len(recent_collection.find_calls) == 4
+    assert len(memory_redis.values) == 2
     assert memory_redis.get_calls == valid_cache_get_calls
     assert all(
         options == {"maxTimeMS": 5000}
@@ -363,6 +419,19 @@ def test_all_kev_cache_uses_canonical_validated_query(monkeypatch):
         api_module = importlib.import_module("schema.api")
         resource = api_module.AllKevVulnerabilitiesResource()
         app = Flask(__name__)
+        admitted_requests = []
+        original_run_backend_tasks = api_module.run_backend_tasks
+
+        def recording_run_backend_tasks(tasks, timeout):
+            """Record aggregate admission while preserving real task execution."""
+            admitted_requests.append(timeout)
+            return original_run_backend_tasks(tasks, timeout=timeout)
+
+        monkeypatch.setattr(
+            api_module,
+            "run_backend_tasks",
+            recording_run_backend_tasks,
+        )
 
         valid_request_groups = (
             (
@@ -383,6 +452,24 @@ def test_all_kev_cache_uses_canonical_validated_query(monkeypatch):
                 with app.test_request_context(url):
                     response = resource.get()
                 assert response.status_code == 200
+
+        default_aliases = (
+            "/kev?page=1",
+            "/api/kev/?per_page=25&page=1",
+        )
+        for url in default_aliases:
+            with app.test_request_context(url):
+                response = resource.get()
+            assert response.status_code == 200
+
+        deep_page_requests = (
+            "/kev?page=11&per_page=25",
+            "/kev?per_page=25&page=11",
+        )
+        for url in deep_page_requests:
+            with app.test_request_context(url):
+                response = resource.get()
+            assert response.status_code == 200
         valid_cache_get_calls = memory_redis.get_calls
 
         invalid_urls = (
@@ -396,8 +483,10 @@ def test_all_kev_cache_uses_canonical_validated_query(monkeypatch):
     finally:
         sys.modules.pop("schema.api", None)
 
-    assert len(kev_collection.count_calls) == 2
-    assert len(kev_collection.find_calls) == 2
+    assert len(kev_collection.count_calls) == 7
+    assert len(kev_collection.find_calls) == 7
+    assert len(memory_redis.values) == 1
+    assert admitted_requests == [api_module.GREENLET_TIMEOUT] * 7
     assert memory_redis.get_calls == valid_cache_get_calls
     assert all(
         options == {"maxTimeMS": 5000}
@@ -846,6 +935,17 @@ def test_mongo_checkout_wait_has_a_bounded_timeout():
             },
             "/kev/CVE-2026-0001",
         ),
+        (
+            "VulnerabilityResource",
+            {
+                "_id": "record-1",
+                "cveID": "CVE-2026-0001",
+                "dateAdded": "2026-01-01",
+                "dueDate": "2026-01-22",
+                "githubPocs": ["https://example.test/poc"],
+            },
+            "/api/kev/CVE-2026-0001?references=pocs",
+        ),
     ],
 )
 def test_manual_cache_resources_do_not_query_mongo_on_hit(
@@ -899,6 +999,175 @@ def test_manual_cache_resources_do_not_query_mongo_on_hit(
 
     assert response.status_code == 200
     assert fake_collection.find_one_calls == 0
+
+
+def test_public_cve_query_routes_canonicalize_before_cache(monkeypatch):
+    """Equivalent CVE queries share fills and ignored parameters are rejected."""
+
+    class LookupCollection:
+        """Record public point lookups while returning no matching document."""
+
+        def __init__(self):
+            """Initialize an empty lookup log."""
+            self.find_one_calls = []
+
+        def find_one(self, query):
+            """Record the canonical lookup and return a cacheable miss."""
+            self.find_one_calls.append(query)
+            return None
+
+    lookup_collection = LookupCollection()
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = lookup_collection
+    fake_database.all_vulns_collection = lookup_collection
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://kevin.gtfkd.com")
+    monkeypatch.setenv("TRUSTED_HOSTS", "kevin.gtfkd.com,localhost")
+    sys.modules.pop("kevin", None)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        kevin_module = importlib.import_module("kevin")
+        client = kevin_module.app.test_client()
+
+        exists_responses = (
+            client.get("/kev/exists?cve=CVE-2026-0001"),
+            client.get("/kev/exists?cve=cve-2026-0001"),
+        )
+        kev_responses = (
+            client.get("/openai/kev?cve=CVE-2026-0001"),
+            client.get("/openai/kev?cve=cve-2026-0001"),
+        )
+        vuln_responses = (
+            client.get("/openai/vuln?cve=CVE-2026-0001"),
+            client.get("/openai/vuln?cve=cve-2026-0001"),
+        )
+        invalid_responses = (
+            client.get("/kev/exists?cve=CVE-2026-0001&nonce=1"),
+            client.get("/openai/kev?cve=CVE-2026-0001&nonce=1"),
+            client.get("/openai/vuln?cve=CVE-2026-0001&cve=CVE-2026-0001"),
+        )
+    finally:
+        sys.modules.pop("kevin", None)
+        sys.modules.pop("schema.api", None)
+
+    assert [response.status_code for response in exists_responses] == [200, 200]
+    assert [response.status_code for response in kev_responses] == [404, 404]
+    assert [response.status_code for response in vuln_responses] == [404, 404]
+    assert [response.status_code for response in invalid_responses] == [400, 400, 400]
+    assert lookup_collection.find_one_calls == [
+        {"cveID": "CVE-2026-0001"},
+        {"cveID": "CVE-2026-0001"},
+        {"_id": "CVE-2026-0001"},
+    ]
+    assert len(memory_redis.values) == 3
+
+
+def test_public_cve_path_routes_canonicalize_before_cache(monkeypatch):
+    """NVD, MITRE, and report aliases validate CVEs before shared fills."""
+
+    class LookupCollection:
+        """Return one minimal CVE record and count admitted point lookups."""
+
+        def __init__(self):
+            """Initialize an empty lookup log."""
+            self.find_one_calls = []
+
+        def find_one(self, query):
+            """Record the canonical lookup and return representative data."""
+            self.find_one_calls.append(query)
+            return {
+                "_id": "CVE-2026-0001",
+                "namespaces": {
+                    "nvd_nist_gov": {},
+                    "cve_org": {},
+                },
+            }
+
+    lookup_collection = LookupCollection()
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = lookup_collection
+    fake_database.all_vulns_collection = lookup_collection
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+    monkeypatch.setenv("TRUSTED_HOSTS", "localhost")
+    sys.modules.pop("kevin", None)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        kevin_module = importlib.import_module("kevin")
+        client = kevin_module.app.test_client()
+        responses = (
+            client.get("/vuln/cve-2026-0001/nvd"),
+            client.get("/api/vuln/CVE-2026-0001/nvd"),
+            client.get("/vuln/cve-2026-0001/mitre"),
+            client.get("/api/vuln/CVE-2026-0001/mitre"),
+            client.get("/vuln/cve-2026-0001/report"),
+            client.get("/vuln/CVE-2026-0001/report"),
+        )
+        invalid_responses = (
+            client.get("/vuln/not-a-cve/nvd"),
+            client.get("/api/vuln/not-a-cve/mitre"),
+            client.get("/vuln/not-a-cve/report"),
+        )
+    finally:
+        sys.modules.pop("kevin", None)
+        sys.modules.pop("schema.api", None)
+
+    assert [response.status_code for response in responses] == [200] * 6
+    assert [response.status_code for response in invalid_responses] == [400] * 3
+    assert lookup_collection.find_one_calls == [
+        {"_id": "CVE-2026-0001"},
+        {"_id": "CVE-2026-0001"},
+        {"_id": "CVE-2026-0001"},
+    ]
+    assert len(memory_redis.values) == 3
+
+
+def test_homepage_rejects_untrusted_hosts_and_uses_public_origin(monkeypatch):
+    """Cached homepage metadata never derives its authority from request Host."""
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = object()
+    fake_database.all_vulns_collection = object()
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    cache_module = importlib.import_module("utils.cache_manager")
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(MemoryRedis()),
+    )
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://kevin.gtfkd.com")
+    monkeypatch.setenv("TRUSTED_HOSTS", "kevin.gtfkd.com,localhost")
+    sys.modules.pop("kevin", None)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        kevin_module = importlib.import_module("kevin")
+        client = kevin_module.app.test_client()
+        untrusted_response = client.get("/", headers={"Host": "evil.example"})
+        trusted_response = client.get("/", headers={"Host": "localhost"})
+    finally:
+        sys.modules.pop("kevin", None)
+        sys.modules.pop("schema.api", None)
+
+    assert untrusted_response.status_code == 400
+    assert trusted_response.status_code == 200
+    homepage = trusted_response.get_data(as_text=True)
+    assert 'href="https://kevin.gtfkd.com/"' in homepage
+    assert "evil.example" not in homepage
 
 
 def test_kevin_routes_use_bounded_backend_admission():

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -920,7 +920,7 @@ def test_schema_resources_never_block_in_greenlet_pool_spawn():
 
 
 def test_recent_kev_query_is_admitted_canonical_bounded_and_cached(monkeypatch):
-    """Recent KEV responses finish bounded backend work before caching."""
+    """Recent KEV aliases and limits share one bounded maximum-result fill."""
 
     class RecordingCursor:
         """Record query bounds and return one representative vulnerability."""
@@ -945,15 +945,16 @@ def test_recent_kev_query_is_admitted_canonical_bounded_and_cached(monkeypatch):
             return self
 
         def __iter__(self):
-            """Yield a record that exercises the public serializer."""
+            """Yield records that prove requested limits are sliced after caching."""
             return iter(
                 [
                     {
-                        "_id": "record-1",
-                        "cveID": "CVE-2026-0001",
+                        "_id": f"record-{index}",
+                        "cveID": f"CVE-2026-{index:04d}",
                         "dateAdded": "2026-01-01",
                         "dueDate": "2026-01-22",
                     }
+                    for index in range(1, 4)
                 ]
             )
 
@@ -1006,17 +1007,14 @@ def test_recent_kev_query_is_admitted_canonical_bounded_and_cached(monkeypatch):
         )
 
         valid_urls = (
-            "/kev/recent?days=007&limit=025",
-            "/kev/recent?limit=25&days=7",
+            "/kev/recent?days=007&limit=1",
+            "/api/kev/recent/?limit=2&days=7",
+            "/kev/recent/?days=7",
         )
         responses = []
         for url in valid_urls:
             with app.test_request_context(url):
                 responses.append(resource.get())
-
-        # Omitting the optional limit preserves the documented maximum default.
-        with app.test_request_context("/kev/recent?days=7"):
-            default_limit_response = resource.get()
 
         cache_get_calls_before_invalid_requests = memory_redis.get_calls
         invalid_urls = (
@@ -1037,23 +1035,23 @@ def test_recent_kev_query_is_admitted_canonical_bounded_and_cached(monkeypatch):
     finally:
         sys.modules.pop("schema.api", None)
 
-    assert [response.status_code for response in responses] == [200, 200]
+    assert [response.status_code for response in responses] == [200, 200, 200]
     assert all(not response.is_streamed for response in responses)
-    assert responses[0].get_json() == responses[1].get_json()
-    assert default_limit_response.status_code == 200
-    assert not default_limit_response.is_streamed
+    assert [len(response.get_json()) for response in responses] == [1, 2, 3]
+    assert responses[0].get_json() == responses[1].get_json()[:1]
+    assert responses[1].get_json() == responses[2].get_json()[:2]
 
-    # Equivalent explicit queries share one origin fill; the default is a
-    # separate, legitimate cache identity with its documented result limit.
-    assert len(recent_collection.find_calls) == 2
-    assert len(memory_redis.values) == 2
-    assert admitted_requests == [api_module.GREENLET_TIMEOUT] * 2
+    # All aliases and requested prefixes share one maximum-size dataset.
+    assert len(recent_collection.find_calls) == 1
+    assert len(memory_redis.values) == 1
+    assert admitted_requests == [api_module.GREENLET_TIMEOUT]
+    assert len(
+        {
+            api_module.recent_kev_cache_key(days)
+            for days in range(101)
+        }
+    ) == 101
     assert recent_collection.cursors[0].operations == [
-        ("sort", "dateAdded", api_module.DESCENDING),
-        ("limit", 25),
-        ("max_time_ms", api_module.MONGO_QUERY_MAX_TIME_MS),
-    ]
-    assert recent_collection.cursors[1].operations == [
         ("sort", "dateAdded", api_module.DESCENDING),
         ("limit", api_module.RECENT_KEV_MAX_RESULTS),
         ("max_time_ms", api_module.MONGO_QUERY_MAX_TIME_MS),

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -285,13 +285,26 @@ class CacheManager:
 # Initialize a global cache manager
 cache_manager = CacheManager(redis_client)
 
-def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
+def kev_cache(
+    timeout=120,
+    key_prefix="cache_",
+    query_string=False,
+    canonical_args=None,
+    include_path=True,
+    cache_if=None,
+):
     """Cache Flask responses using route-aware, optionally canonical query keys.
 
     ``query_string`` may be ``True`` to preserve the raw query string or a
     callable that returns validated canonical query items. A canonicalizer may
     raise ``ValueError`` to reject a request with a fixed client-safe message
     before cache or origin access.
+
+    ``canonical_args`` performs the same validation and normalization for path
+    arguments. ``include_path=False`` lets public aliases share one logical
+    cache entry. ``cache_if`` receives the canonical query items and can bypass
+    caching for valid high-cardinality requests; those handlers remain
+    responsible for applying backend admission control.
     """
     def decorator(func):
         @functools.wraps(func)
@@ -299,11 +312,27 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             # Skip self (args[0]) if this is a method
             method_args = args[1:] if args and hasattr(args[0], '__class__') else args
 
+            if callable(canonical_args):
+                try:
+                    method_args = canonical_args(*args, **kwargs)
+                    cache_kwargs = {}
+                except ValueError:
+                    return make_response(
+                        {"message": "Invalid path parameters"},
+                        400,
+                    )
+            else:
+                cache_kwargs = kwargs
+
             prefix_value = key_prefix
             if callable(prefix_value):
                 prefix_value = prefix_value(*args, **kwargs)
 
-            path = request.path if has_request_context() else None
+            path = (
+                request.path
+                if include_path and has_request_context()
+                else None
+            )
             query_items = None
             if has_request_context() and callable(query_string):
                 try:
@@ -316,9 +345,20 @@ def kev_cache(timeout=120, key_prefix="cache_", query_string=False):
             elif query_string and has_request_context():
                 query_items = list(request.args.lists())
 
+            # Valid requests outside the bounded cache policy still execute,
+            # but they do not consume Redis or singleflight cardinality.
+            if callable(cache_if) and not cache_if(query_items):
+                try:
+                    return func(*args, **kwargs)
+                except PyMongoError:
+                    return make_response(
+                        {"error": "Backend temporarily unavailable"},
+                        503,
+                    )
+
             cache_context = {
                 "method_args": method_args,
-                "kwargs": kwargs,
+                "kwargs": cache_kwargs,
                 "query_items": query_items,
                 "path": path,
             }

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -91,3 +91,28 @@ def sanitize_query(query):
         return None
 
     return query
+
+
+def normalize_cve_id(query):
+    """Return one canonical CVE identifier or reject the supplied value.
+
+    Sanitization alone can transform malformed input into a different valid
+    identifier. Requiring the sanitized value to match the complete CVE format
+    ensures cache identity and database identity use the same validated value.
+    """
+    sanitized_query = sanitize_query(query)
+    if not sanitized_query or not CVE_ID_FORMAT_RE.fullmatch(sanitized_query):
+        raise ValueError("Invalid CVE ID")
+    return sanitized_query.upper()
+
+
+def canonical_cve_arguments(*args, **kwargs):
+    """Canonicalize a route CVE argument for alias-independent cache keys."""
+    cve_id = kwargs.get("cve_id")
+    if cve_id is None and args:
+        # Resource methods include ``self`` first, so the CVE is always the
+        # final positional value for every currently decorated point route.
+        cve_id = args[-1]
+    if cve_id is None:
+        raise ValueError("CVE ID is required")
+    return (normalize_cve_id(cve_id),)


### PR DESCRIPTION
## Summary

This PR now bundles the validated hardening work from the follow-up review of KEVin’s intentionally unauthenticated, internet-facing API.

It retains the original `/kev/recent` cache-cardinality fix and adds the five other actionable fixes found during the similar-issue review:

- validate and canonicalize CVE path/query values before cache identity is computed
- bound cache admission for `/kev` list variants
- bound published/modified pagination cache variants
- route the `references=pocs` representation through the shared record cache, singleflight, and MongoDB admission control
- remove request Host from cached homepage metadata and reject untrusted Host headers

## Security impact

The affected patterns allowed anonymous clients to amplify Redis cardinality, cause avoidable MongoDB work, bypass shared backend admission on selected paths, or influence cached canonical/OG metadata.

Relevant classes:

- resource exhaustion / cache-cardinality amplification (CWE-400)
- cache-key inconsistency before validation
- origin-work amplification
- Host-header-derived cache poisoning

Anonymous reads remain intentional. Successful supported API responses remain public and unauthenticated.

## What changed

### Recent KEV datasets

The original patch reduces `days × limit × path` cache identities from **202,000** overlapping entries to **101** bounded daily datasets. Each fill materializes at most 500 records and supported limits are sliced in memory.

### CVE point lookups

`/kev/exists`, `/openai/kev`, `/openai/vuln`, vulnerability reports, NVD, and MITRE routes now:

- reject unsupported, duplicate, or malformed inputs before Redis and MongoDB access
- use uppercase canonical CVE IDs for cache and database identity
- share cache fills across equivalent aliases and casing
- use stable logical prefixes instead of the process-salted Python `hash()`
- execute point lookups through shared backend admission

### KEV list and recent CVE pagination

`/kev` caches only bounded, index-friendly common list variants: pages 1–10, the default 25-result page size, and no search or actor regex. This caps that cache domain at **120 logical entries**.

Published/modified recent CVE routes cache only the default first page for each validated day window and representation, capping that domain at **62 logical entries**.

Other valid pagination, search, actor, and page-size requests are still served. They bypass Redis allocation and execute their count/fetch work through shared fail-fast MongoDB admission with the existing timeout.

### PoC representation

`references=pocs` now reuses the same cached underlying KEV record and per-CVE singleflight as the normal representation. The serializer remains representation-specific, while a cache miss can no longer bypass admission or duplicate the origin fill.

### Public origin metadata

Homepage canonical, Open Graph, Twitter, and structured-data URLs now derive from `PUBLIC_BASE_URL`, not the request Host. `TRUSTED_HOSTS` provides a deployment allowlist and defaults to the production hostname plus local development/health-check hosts.

## Accepted risk: private-node Docker deployment

The review also noted that the repository’s Docker build context can contain a local `.env` file. The owner explicitly accepts this deployment-specific risk because KEVin is built and deployed on a private node.

That item is intentionally **not changed in this PR**. No Dockerfile, build-context, or secret-handling files are modified.

## Compatibility and operational notes

- Public authentication behavior is unchanged.
- Existing route aliases and trailing-slash forms remain supported.
- Existing successful response shapes remain unchanged.
- High-cardinality but valid list requests may no longer receive an application-level Redis hit; this is intentional to bound shared cache memory.
- Deployments must include every reverse-proxy and health-check hostname in `TRUSTED_HOSTS`.
- `PUBLIC_BASE_URL` defaults to `https://kevin.gtfkd.com`.

## Validation

Passed locally:

- `env/bin/pytest -q -p no:cacheprovider tests/security_regression_test.py` — **30 passed**
- `env/bin/pytest -q -p no:cacheprovider --ignore=tests/sanitization_test.py` — **36 passed**
- `env/bin/python -m compileall -q kevin.py schema/api.py utils tests/security_regression_test.py`
- `git diff --check`
- `git verify-commit HEAD` — good signature

The regressions prove:

- invalid inputs stop before cache and origin access
- aliases and equivalent CVE spellings share fills
- cacheable list domains remain bounded
- non-cacheable valid list requests still run under admission
- PoC cache hits do not query MongoDB
- untrusted Host headers are rejected and cached metadata uses the configured public origin

The complete pytest collection still requires a live MongoDB instance because `tests/sanitization_test.py` imports the application and connects during collection. Without MongoDB it stops at the existing `Could not connect to MongoDB after multiple attempts` error; all Mongo-independent tests above pass.