### PR TITLE
Bound public origin work and browser trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ MONGODB_URI_PROD=mongodb://MONGO_PROD_IP:27017/
 MONGODB_URI_DEV=mongodb://localhost:27017/
 PUBLIC_BASE_URL=https://kevin.gtfkd.com
 TRUSTED_HOSTS=kevin.gtfkd.com,localhost,127.0.0.1
+ORIGIN_RATE_LIMIT_WINDOW_SECONDS=1
+UNCACHED_QUERY_RATE_LIMIT=10
+POINT_MISS_RATE_LIMIT=20
+NEGATIVE_CACHE_TIMEOUT=15
+NEGATIVE_CACHE_MAX_ENTRIES=1024
 ```
 
 Feel free to edit the mongodb in use or variable names. I have both in here since I work on prod and dev mongodbs for the hosted version of KEVin at kevin.gtfkd.com/*.
@@ -43,6 +48,13 @@ Feel free to edit the mongodb in use or variable names. I have both in here sinc
 `PUBLIC_BASE_URL` is the canonical public origin used in homepage metadata.
 `TRUSTED_HOSTS` is a comma-separated allowlist for accepted HTTP Host headers;
 include the hostname used by local health checks and reverse proxies.
+
+The origin-admission settings are read once at startup. Redis enforces the
+shared per-window limits across workers: `UNCACHED_QUERY_RATE_LIMIT` covers
+valid list variants outside the bounded cache policy, and
+`POINT_MISS_RATE_LIMIT` covers point-route cache misses. Negative point results
+use `NEGATIVE_CACHE_TIMEOUT`; manual point resources also keep at most
+`NEGATIVE_CACHE_MAX_ENTRIES` short-lived misses in each worker.
 
 **Set up MongoDB:**
 

--- a/kevin.py
+++ b/kevin.py
@@ -23,7 +23,12 @@ from utils.backend_capacity import (
     BackendTimeoutError,
     run_backend_tasks,
 )
-from utils.cache_manager import kev_cache as cache 
+from utils.cache_manager import (
+    NEGATIVE_CACHE_TIMEOUT,
+    POINT_MISS_RATE_BUCKET,
+    POINT_MISS_RATE_LIMIT,
+    kev_cache as cache,
+)
 from utils.sanitizer import (
     canonical_cve_arguments,
     normalize_cve_id,
@@ -89,6 +94,29 @@ def reject_untrusted_host():
     if hostname not in TRUSTED_HOSTS:
         return jsonify({"error": "Untrusted Host header"}), 400
     return None
+
+
+@app.after_request
+def add_browser_security_headers(response):
+    """Constrain browser content sources and common MIME-sniffing behavior."""
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' https://code.jquery.com "
+        "https://cdn.jsdelivr.net https://maxcdn.bootstrapcdn.com "
+        "https://cdn.datatables.net; "
+        "style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com "
+        "https://cdn.datatables.net https://cdnjs.cloudflare.com "
+        "https://fonts.googleapis.com; "
+        "font-src 'self' data: https://fonts.gstatic.com "
+        "https://cdnjs.cloudflare.com; "
+        "img-src 'self' data:; connect-src 'self'; object-src 'none'; "
+        "base-uri 'self'; frame-ancestors 'none'",
+    )
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    return response
+
 
 # Route for the root endpoint ("/")
 @app.route("/")
@@ -299,6 +327,9 @@ def lookup_one(database_collection, query):
     key_prefix="cve_exist",
     query_string=canonical_cve_query_items,
     include_path=False,
+    miss_rate_limit=POINT_MISS_RATE_LIMIT,
+    rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+    negative_timeout=NEGATIVE_CACHE_TIMEOUT,
 )
 def cve_exist():
     """
@@ -340,6 +371,9 @@ def cve_exist():
     key_prefix="vulnerability_report",
     canonical_args=canonical_cve_arguments,
     include_path=False,
+    miss_rate_limit=POINT_MISS_RATE_LIMIT,
+    rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+    negative_timeout=NEGATIVE_CACHE_TIMEOUT,
 )
 def vulnerability_report(cve_id):
     """
@@ -409,6 +443,9 @@ def not_found(e):
     key_prefix="openai_kev",
     query_string=canonical_cve_query_items,
     include_path=False,
+    miss_rate_limit=POINT_MISS_RATE_LIMIT,
+    rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+    negative_timeout=NEGATIVE_CACHE_TIMEOUT,
 )
 def openai_kev():
     """
@@ -455,6 +492,9 @@ def openai_kev():
     key_prefix="openai_vuln",
     query_string=canonical_cve_query_items,
     include_path=False,
+    miss_rate_limit=POINT_MISS_RATE_LIMIT,
+    rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+    negative_timeout=NEGATIVE_CACHE_TIMEOUT,
 )
 def openai_vuln():
     """

--- a/schema/api.py
+++ b/schema/api.py
@@ -26,6 +26,12 @@ from utils.backend_capacity import (
 )
 from utils.cache_manager import (
     CacheBackendUnavailable,
+    NEGATIVE_CACHE_TIMEOUT,
+    POINT_MISS_RATE_BUCKET,
+    POINT_MISS_RATE_LIMIT,
+    RATE_LIMIT_WINDOW_SECONDS,
+    UNCACHED_QUERY_RATE_LIMIT,
+    OriginRateLimitExceeded,
     cache_manager,
     kev_cache as cache,
 )
@@ -268,12 +274,23 @@ def recent_vulnerability_cache_prefix(resource):
 
 
 class BaseResource(Resource):
+    """Provide consistent JSON and admission-control responses."""
+
     def handle_error(self, message, status=404):
+        """Return a JSON error response with the requested HTTP status."""
         response = {"message": message}
         return make_response(jsonify(response), status)
 
     def make_json_response(self, data, status=200):
+        """Return JSON data with the requested HTTP status."""
         return make_response(jsonify(data), status)
+
+    def handle_rate_limit(self):
+        """Return the shared point-miss budget response."""
+        response = self.handle_error("Origin rate limit exceeded", 429)
+        response.headers["Retry-After"] = str(RATE_LIMIT_WINDOW_SECONDS)
+        return response
+
 
 # Resource for fectching mitre and nvd data from the cveland via CVE-ID,
 # which is the _id field in the cveland collection
@@ -295,9 +312,9 @@ class cveLandResource(BaseResource):
                   error message if the input parameters are invalid or the
                   vulnerability is not found.
         """
-        # Sanitize the CVE ID first. Fix #179
-        sanitized_cve_id = sanitize_query(cve_id)
-        if sanitized_cve_id is None:
+        try:
+            sanitized_cve_id = normalize_cve_id(cve_id)
+        except ValueError:
             return self.handle_error("Invalid CVE ID", 400)
 
         # Use partial to create a new function that includes the cve_id in the key prefix
@@ -311,6 +328,10 @@ class cveLandResource(BaseResource):
             return self.make_json_response(cached_data)
 
         cache_key = cache_key_func()
+        negative_key = f"negative_{cache_key}"
+        if cache_manager.has_negative(negative_key):
+            return self.handle_error("Vulnerability not found")
+
         with cache_manager.singleflight(cache_key) as acquired:
             if not acquired:
                 return self.handle_error("Backend busy", 503)
@@ -321,6 +342,19 @@ class cveLandResource(BaseResource):
                 return self.handle_error("Cache temporarily unavailable", 503)
             if cached_data is not None:
                 return self.make_json_response(cached_data)
+            if cache_manager.has_negative(negative_key):
+                return self.handle_error("Vulnerability not found")
+
+            try:
+                cache_manager.enforce_rate_limit(
+                    POINT_MISS_RATE_BUCKET,
+                    POINT_MISS_RATE_LIMIT,
+                    RATE_LIMIT_WINDOW_SECONDS,
+                )
+            except OriginRateLimitExceeded:
+                return self.handle_rate_limit()
+            except CacheBackendUnavailable:
+                return self.handle_error("Cache temporarily unavailable", 503)
 
             try:
                 vulnerability = run_backend_tasks(
@@ -338,6 +372,8 @@ class cveLandResource(BaseResource):
                 data = serialize_all_vulnerability(vulnerability)
                 cache_manager.set(cache_key, data, timeout=180)
                 return self.make_json_response(data)
+
+            cache_manager.remember_negative(negative_key)
 
         return self.handle_error("Vulnerability not found")
 
@@ -360,6 +396,9 @@ class cveNVDResource(BaseResource):
         key_prefix="cve_nvd",
         canonical_args=canonical_cve_arguments,
         include_path=False,
+        miss_rate_limit=POINT_MISS_RATE_LIMIT,
+        rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+        negative_timeout=NEGATIVE_CACHE_TIMEOUT,
     )
     def get(self, cve_id):
         """
@@ -407,6 +446,9 @@ class cveMitreResource(BaseResource):
         key_prefix="cve_mitre",
         canonical_args=canonical_cve_arguments,
         include_path=False,
+        miss_rate_limit=POINT_MISS_RATE_LIMIT,
+        rate_limit_bucket=POINT_MISS_RATE_BUCKET,
+        negative_timeout=NEGATIVE_CACHE_TIMEOUT,
     )
     def get(self, cve_id):
         """
@@ -474,9 +516,9 @@ class VulnerabilityResource(BaseResource):
                   error message if the input parameters are invalid or the
                   vulnerability is not found.
         """
-        # Sanitize the input CVE ID
-        sanitized_cve_id = sanitize_query(cve_id)
-        if sanitized_cve_id is None:
+        try:
+            sanitized_cve_id = normalize_cve_id(cve_id)
+        except ValueError:
             return self.handle_error("Invalid CVE ID", 400)
         # Get the 'references' argument and sanitize it
         references_raw = request.args.get('references')
@@ -489,6 +531,8 @@ class VulnerabilityResource(BaseResource):
             vulnerability = self.load_vulnerability(sanitized_cve_id)
         except CacheBackendUnavailable:
             return self.handle_error("Cache temporarily unavailable", 503)
+        except OriginRateLimitExceeded:
+            return self.handle_rate_limit()
         except BackendBusyError:
             return self.handle_error("Backend busy", 503)
         except BackendTimeoutError:
@@ -506,29 +550,43 @@ class VulnerabilityResource(BaseResource):
 
     def load_vulnerability(self, sanitized_cve_id):
         """Load one shared cached record for normal and PoC representations."""
-        cached_data = self.get_cached_data(sanitized_cve_id)
+        cache_key = f"kev_data_{sanitized_cve_id}"
+        negative_key = f"negative_{cache_key}"
+        cached_data = self.get_cached_data(cache_key)
         if cached_data is not None:
             return cached_data
+        if cache_manager.has_negative(negative_key):
+            return None
 
-        with cache_manager.singleflight(sanitized_cve_id) as acquired:
+        with cache_manager.singleflight(cache_key) as acquired:
             if not acquired:
                 raise BackendBusyError("CVE cache fill already in progress")
 
-            cached_data = cache_manager.get(sanitized_cve_id)
+            cached_data = cache_manager.get(cache_key)
             if cached_data is not None:
                 return cached_data
+            if cache_manager.has_negative(negative_key):
+                return None
+
+            cache_manager.enforce_rate_limit(
+                POINT_MISS_RATE_BUCKET,
+                POINT_MISS_RATE_LIMIT,
+                RATE_LIMIT_WINDOW_SECONDS,
+            )
 
             vulnerability = run_backend_tasks(
                 [partial(self.query_vulnerability, sanitized_cve_id)],
                 timeout=GREENLET_TIMEOUT,
             )[0]
             if vulnerability:
-                cache_manager.set(sanitized_cve_id, vulnerability)
+                cache_manager.set(cache_key, vulnerability)
+            else:
+                cache_manager.remember_negative(negative_key)
             return vulnerability
 
-    def get_cached_data(self, sanitized_cve_id):
+    def get_cached_data(self, cache_key):
         """Fetch cached data."""
-        return cache_manager.get(sanitized_cve_id)
+        return cache_manager.get(cache_key)
 
     def query_vulnerability(self, sanitized_cve_id):
         """Query the database for the vulnerability."""
@@ -542,6 +600,8 @@ class AllKevVulnerabilitiesResource(BaseResource):
         query_string=canonical_all_kev_query_items,
         include_path=False,
         cache_if=should_cache_all_kev,
+        uncached_rate_limit=UNCACHED_QUERY_RATE_LIMIT,
+        rate_limit_bucket="all_kev_uncached",
     )
     def get(self):
         """
@@ -771,6 +831,8 @@ class RecentVulnerabilitiesByDaysResource(BaseResource):
         query_string=canonical_recent_vulnerability_query_items,
         include_path=False,
         cache_if=should_cache_recent_vulnerabilities,
+        uncached_rate_limit=UNCACHED_QUERY_RATE_LIMIT,
+        rate_limit_bucket="recent_vulnerability_uncached",
     )
     def get(self):
         """

--- a/static/cve_visualization.html
+++ b/static/cve_visualization.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <!-- Font Awesome for icons -->
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
     <style>
         /* Layout */
         .navbar-brand {
@@ -984,7 +984,7 @@
                             <button class="btn btn-danger" id="resetView"><i class="fas fa-redo"></i> Reset</button>
                             <div class="input-group" style="width: 220px;">
                                 <div class="input-group-prepend"><span class="input-group-text">per_page</span></div>
-                                <input type="number" id="perPage" class="form-control" min="1" max="100" value="25">
+                                <input type="number" id="perPage" class="form-control" min="25" max="100" value="25">
                             </div>
                         </div>
                     </div>
@@ -1158,6 +1158,9 @@
         let loadAllActive = false;
         let actorDisplayName = '';
         let pageInfo = { current: 0, total: null };
+        // Bound every automatic series so one browser action cannot fan out
+        // into hundreds of API and MongoDB requests.
+        const MAX_AUTOMATIC_PAGES = 10;
         const POSITION_STORAGE_KEY = 'kev-graph-pos-v1';
         const MAX_POSITION_STORE = 400;
         const persistedPositions = loadPersistedPositions();
@@ -1375,7 +1378,7 @@
 
         document.getElementById('perPage').addEventListener('change', function () {
             const val = parseInt(this.value, 10);
-            perPage = Math.max(1, Math.min(100, isNaN(val) ? 25 : val));
+            perPage = Math.max(25, Math.min(100, isNaN(val) ? 25 : val));
             this.value = perPage;
         });
 
@@ -1605,18 +1608,22 @@
 
         function loadMoreDataByActor(actor, totalPages) {
             let page = 2;
+            const automaticPageLimit = Math.min(totalPages, MAX_AUTOMATIC_PAGES);
             actorLoadActive = true;
             const encodedActor = encodeURIComponent(actor);
 
             const fetchPage = () => {
                 if (!actorLoadActive) return;
-                if (page > totalPages) {
+                if (page > automaticPageLimit) {
                     actorLoadActive = false;
                     if (actorLoadTimer) {
                         clearTimeout(actorLoadTimer);
                         actorLoadTimer = null;
                     }
-                    return; // End recursion
+                    if (totalPages > automaticPageLimit) {
+                        setStatus(`Stopped after ${automaticPageLimit} pages. Refine the actor search to load a smaller result set.`);
+                    }
+                    return; // End the bounded request series
                 }
 
                 cancelCurrentRequest(); // Cancel any ongoing request before starting a new one
@@ -1686,23 +1693,28 @@
                         performActorGraphSearch(lastActorSearchTerm, { focus: false, updateStatus: false });
                     }
                     const totalPages = first.total_pages;
-                    updateProgress(1, totalPages);
-                    setStatus(`Loading all pages: 1/${totalPages}`);
-                    pageInfo = { current: 1, total: totalPages || pageInfo.total };
+                    const automaticPageLimit = Math.min(totalPages, MAX_AUTOMATIC_PAGES);
+                    updateProgress(1, automaticPageLimit);
+                    setStatus(`Loading up to ${automaticPageLimit} pages: 1/${automaticPageLimit}`);
+                    pageInfo = { current: 1, total: automaticPageLimit || pageInfo.total };
                     updateStatusChips();
                     // Sequentially fetch remaining pages
                     let p = 2;
                     const loop = () => {
                         if (!loadAllActive) return;
-                        if (p > totalPages) {
+                        if (p > automaticPageLimit) {
                             loadAllActive = false;
                             if (loadAllTimer) {
                                 clearTimeout(loadAllTimer);
                                 loadAllTimer = null;
                             }
-                            setStatus('All pages loaded.');
+                            setStatus(
+                                totalPages > automaticPageLimit
+                                    ? `Stopped after ${automaticPageLimit} pages. Use filters to narrow the dataset.`
+                                    : 'All pages loaded.'
+                            );
                             hideProgress();
-                            pageInfo = { current: totalPages, total: totalPages };
+                            pageInfo = { current: automaticPageLimit, total: automaticPageLimit };
                             updateStatusChips();
                             fitToScreen();
                             return;
@@ -1724,9 +1736,9 @@
                                 if (lastActorSearchTerm) {
                                     performActorGraphSearch(lastActorSearchTerm, { focus: false, updateStatus: false });
                                 }
-                                updateProgress(p, totalPages);
-                                setStatus(`Loading all pages: ${p}/${totalPages}`);
-                                pageInfo = { current: p, total: totalPages };
+                                updateProgress(p, automaticPageLimit);
+                                setStatus(`Loading up to ${automaticPageLimit} pages: ${p}/${automaticPageLimit}`);
+                                pageInfo = { current: p, total: automaticPageLimit };
                                 updateStatusChips();
                                 p++;
                                 loadAllTimer = setTimeout(() => {
@@ -3415,13 +3427,13 @@
                 const params = new URLSearchParams(window.location.search);
                 const actor = params.get('actor');
                 const p = parseInt(params.get('per_page') || '0', 10);
-                if (p) { perPage = Math.max(1, Math.min(100, p)); document.getElementById('perPage').value = perPage; }
+                if (p) { perPage = Math.max(25, Math.min(100, p)); document.getElementById('perPage').value = perPage; }
                 if (actor) {
                     document.getElementById('actorSearch').value = actor;
                     actorDisplayName = actor;
                     searchedActor = actor.toLowerCase();
                     updateStatusChips();
-                    fetchDataByActor(searchedActor);
+                    setStatus('Actor query prefilled. Press Search to load results.');
                 }
             } catch { /* ignore */ }
         })();
@@ -3434,8 +3446,8 @@
         bindKeyboardShortcuts();
 
     </script>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4Twt/qOuYxE721u19sVFLVSA4hf/rRt6PrZTmiPltdZcI7q7PXQBYTKyf" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/static/viz.html
+++ b/static/viz.html
@@ -512,10 +512,10 @@
         </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js" integrity="sha384-eMNCOe7tC1doHpGoWe/6oMVemdAVTMs2xqW4mwXrXsW0L84Iytr2wi5v2QjrP/xp" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js" integrity="sha384-RxzVJNpULMjRDJ3nd+aAVYb11VBDmhgIonMdvYdLxYvylOdEl6pprk4R4PK0t3xG" crossorigin="anonymous"></script>
     <script>
         $(document).ready(function () {
             function textValue(value, fallback = '') {

--- a/templates/example.html
+++ b/templates/example.html
@@ -118,8 +118,8 @@ print(data)
     </code></pre>
 </div>
 <!-- Include Bootstrap JS and jQuery -->
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js" integrity="sha384-eMNCOe7tC1doHpGoWe/6oMVemdAVTMs2xqW4mwXrXsW0L84Iytr2wi5v2QjrP/xp" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/tests/sanitization_test.py
+++ b/tests/sanitization_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Tests for shared query sanitization behavior."""
+"""Unit tests for shared query sanitization behavior."""
 
-from kevin import sanitize_query
-from schema.api import sanitize_query as api_sanitize_query
+from utils.sanitizer import sanitize_query
+
 
 def test_sanitize_query():
     """Sanitize common inputs and reject suspicious SQL-like payloads."""
@@ -33,33 +33,3 @@ def test_sanitize_query():
     # Test for double URL encoded values
     assert sanitize_query("%253Cscript%253E") == "script"
     assert sanitize_query("%2520") == ""
-
-def test_api_sanitize_query():
-    """Apply the same sanitizer expectations through the API module export."""
-    assert api_sanitize_query("abc123") == "abc123"
-    assert api_sanitize_query("abc 123") == "abc 123"
-    assert api_sanitize_query("abc-123") == "abc-123"
-    assert api_sanitize_query("abc@123") == "abc123"
-    assert api_sanitize_query(None) is None
-    assert api_sanitize_query(123) == "123"
-    assert api_sanitize_query("CVE-1234-123456") == "CVE-1234-123456"
-    assert api_sanitize_query("cve-1234-123456") == "CVE-1234-123456"
-
-    # Test for potential MongoDB injection attacks
-    assert api_sanitize_query("{$ne: null}") == "ne null"
-    assert api_sanitize_query("{ $where: 'this.a > this.b' }") == "where thisa thisb"
-
-    # Test for URL encoded values
-    assert api_sanitize_query("%20") == ""
-    assert api_sanitize_query("%3Cscript%3E") == "script"
-
-    # Additional tests for malicious input
-    assert api_sanitize_query("<img src='x' onerror='alert(1)'>") == "img srcx onerroralert1"
-    assert api_sanitize_query("1; DROP TABLE users") is None
-    assert api_sanitize_query("admin' --") == "admin --"
-    link_payload = "<a href='http://example.com' target='_blank'>Link</a>"
-    assert api_sanitize_query(link_payload) == "a hrefhttpexamplecom target_blankLinka"
-
-    # Test for double URL encoded values
-    assert api_sanitize_query("%253Cscript%253E") == "script"
-    assert api_sanitize_query("%2520") == ""

--- a/tests/security_regression_test.py
+++ b/tests/security_regression_test.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import importlib
 from pathlib import Path
+import re
 import sys
 import types
 import unittest
@@ -17,6 +18,7 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import MaxConnectionsError
 
 from utils.rss_feed import create_rss_feed
+from utils.sanitizer import normalize_cve_id
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,6 +32,7 @@ class MemoryRedis:
     def __init__(self):
         """Initialize an empty in-memory Redis value store."""
         self.values = {}
+        self.counters = {}
         self.get_calls = 0
 
     def get(self, key):
@@ -40,6 +43,41 @@ class MemoryRedis:
     def setex(self, key, _timeout, value):
         """Store a byte payload using the Redis setex call shape."""
         self.values[key] = value
+
+    def pipeline(self, transaction=True):
+        """Return a tiny transactional-pipeline test double."""
+        assert transaction is True
+        return MemoryRedisPipeline(self)
+
+
+class MemoryRedisPipeline:
+    """Execute the rate-limit commands used by the cache manager."""
+
+    def __init__(self, redis):
+        """Keep the backing in-memory Redis instance and queued commands."""
+        self.redis = redis
+        self.commands = []
+
+    def incr(self, key):
+        """Queue one atomic counter increment."""
+        self.commands.append(("incr", key, None))
+        return self
+
+    def expire(self, key, seconds):
+        """Queue the expiry shape; test counters are reset between tests."""
+        self.commands.append(("expire", key, seconds))
+        return self
+
+    def execute(self):
+        """Execute queued commands and return Redis-compatible results."""
+        results = []
+        for command, key, _value in self.commands:
+            if command == "incr":
+                self.redis.counters[key] = self.redis.counters.get(key, 0) + 1
+                results.append(self.redis.counters[key])
+            else:
+                results.append(True)
+        return results
 
 
 class ExhaustedRedis:
@@ -1165,9 +1203,148 @@ def test_homepage_rejects_untrusted_hosts_and_uses_public_origin(monkeypatch):
 
     assert untrusted_response.status_code == 400
     assert trusted_response.status_code == 200
+    assert "object-src 'none'" in trusted_response.headers["Content-Security-Policy"]
+    assert trusted_response.headers["X-Content-Type-Options"] == "nosniff"
     homepage = trusted_response.get_data(as_text=True)
     assert 'href="https://kevin.gtfkd.com/"' in homepage
     assert "evil.example" not in homepage
+
+
+def test_uncached_origin_requests_have_a_global_rate_budget(monkeypatch):
+    """Valid cache-bypass variants stop before repeated origin execution."""
+    monkeypatch.setenv("REDIS_IP", "localhost")
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+    origin_calls = []
+
+    @cache_module.kev_cache(
+        query_string=lambda: [("search", ["vendor"])],
+        cache_if=lambda _items: False,
+        uncached_rate_limit=1,
+        rate_limit_bucket="test_expensive_query",
+    )
+    def expensive_query():
+        """Record each origin execution that survives cache admission."""
+        origin_calls.append("called")
+        return {"ok": True}
+
+    app = Flask(__name__)
+    app.add_url_rule("/expensive", view_func=expensive_query)
+    client = app.test_client()
+
+    first_response = client.get("/expensive?search=vendor")
+    limited_response = client.get("/expensive?search=vendor")
+
+    assert first_response.status_code == 200
+    assert limited_response.status_code == 429
+    assert limited_response.headers["Retry-After"] == "1"
+    assert origin_calls == ["called"]
+
+
+def test_cve_normalization_rejects_lossy_and_unbounded_identifiers():
+    """CVE canonicalization never repairs malformed attacker input."""
+    assert normalize_cve_id("cve-2026-0001") == "CVE-2026-0001"
+    malformed_values = (
+        "CVE-2026-0001!",
+        "CVE-2026-1",
+        f"CVE-2026-{'1' * 11}",
+        "CVE-1234-1234",
+        "CVE-٢٠٢٦-٠٠٠١",
+    )
+    for malformed_value in malformed_values:
+        with pytest.raises(ValueError):
+            normalize_cve_id(malformed_value)
+
+
+def test_manual_point_routes_reject_malformed_cves_and_cache_misses(monkeypatch):
+    """Manual point resources validate strictly and remember bounded misses."""
+
+    class MissingCollection:
+        """Count point lookups while returning no matching vulnerability."""
+
+        def __init__(self):
+            """Initialize an empty lookup log."""
+            self.find_one_calls = []
+
+        def find_one(self, query):
+            """Record a point lookup and return a miss."""
+            self.find_one_calls.append(query)
+            return None
+
+    missing_collection = MissingCollection()
+    fake_database = types.ModuleType("utils.database")
+    fake_database.collection = missing_collection
+    fake_database.all_vulns_collection = missing_collection
+    monkeypatch.setitem(sys.modules, "utils.database", fake_database)
+    cache_module = importlib.import_module("utils.cache_manager")
+    memory_redis = MemoryRedis()
+    monkeypatch.setattr(
+        cache_module,
+        "cache_manager",
+        cache_module.CacheManager(memory_redis),
+    )
+    monkeypatch.setenv("TRUSTED_HOSTS", "localhost")
+    sys.modules.pop("kevin", None)
+    sys.modules.pop("schema.api", None)
+
+    try:
+        kevin_module = importlib.import_module("kevin")
+        api_module = importlib.import_module("schema.api")
+        monkeypatch.setattr(api_module, "POINT_MISS_RATE_LIMIT", 1)
+        client = kevin_module.app.test_client()
+        malformed_response = client.get("/kev/CVE-2026-0001!")
+        first_miss = client.get("/kev/CVE-2026-9999")
+        repeated_miss = client.get("/kev/CVE-2026-9999")
+        distinct_miss = client.get("/kev/CVE-2026-9998")
+    finally:
+        sys.modules.pop("kevin", None)
+        sys.modules.pop("schema.api", None)
+
+    assert malformed_response.status_code == 400
+    assert [first_miss.status_code, repeated_miss.status_code] == [404, 404]
+    assert distinct_miss.status_code == 429
+    assert distinct_miss.headers["Retry-After"] == "1"
+    assert missing_collection.find_one_calls == [{"cveID": "CVE-2026-9999"}]
+
+
+def test_graph_query_state_cannot_start_an_unbounded_request_loop():
+    """URL state only prefills graph controls and automatic paging is capped."""
+    source = (ROOT / "static" / "cve_visualization.html").read_text()
+    init_start = source.index("function initFromQuery")
+    init_end = source.index("updateGraphSnapshot([], []);", init_start)
+    init_block = source[init_start:init_end]
+
+    assert "const MAX_AUTOMATIC_PAGES = 10;" in source
+    assert "fetchDataByActor(searchedActor)" not in init_block
+    assert "Math.min(totalPages, MAX_AUTOMATIC_PAGES)" in source
+    assert "Math.max(25, Math.min(100, p))" in init_block
+
+
+def test_external_scripts_are_integrity_pinned_and_csp_is_enabled():
+    """Every cross-origin script is byte-pinned and Flask emits a CSP."""
+    html_paths = (
+        ROOT / "templates" / "example.html",
+        ROOT / "static" / "viz.html",
+        ROOT / "static" / "cve_visualization.html",
+    )
+    script_pattern = re.compile(r"<script\s+[^>]*src=\"https://[^>]+>")
+
+    external_scripts = []
+    for html_path in html_paths:
+        external_scripts.extend(script_pattern.findall(html_path.read_text()))
+
+    assert external_scripts
+    assert all('integrity="sha384-' in tag for tag in external_scripts)
+    assert all('crossorigin="anonymous"' in tag for tag in external_scripts)
+
+    source = (ROOT / "kevin.py").read_text()
+    assert "Content-Security-Policy" in source
+    assert "object-src 'none'" in source
 
 
 def test_kevin_routes_use_bounded_backend_admission():

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -1,32 +1,60 @@
 """Redis cache helpers for KEVin API responses."""
 
+from collections import OrderedDict
+from contextlib import contextmanager
+from datetime import datetime
 import functools
 import hashlib
 import hmac
 import logging
 import os
+import re
 import threading
 import time
-from contextlib import contextmanager
+
+import orjson
+from bson import ObjectId
 from flask import Response, has_request_context, make_response, request
 from gevent.lock import Semaphore
 from pymongo.errors import PyMongoError
 from redis.exceptions import RedisError
+
 from utils.cache_config import redis_client
-import re
-import orjson
-from bson import ObjectId
-from datetime import datetime
 
 
 # Regular expression for safe cache keys
 SAFE_KEY_RE = re.compile(r"^[\w\-:]+$")
 CACHE_ENVELOPE_PREFIX = b"kevin-cache-v2:"
 logger = logging.getLogger(__name__)
+RATE_LIMIT_WINDOW_SECONDS = max(
+    1,
+    int(os.getenv("ORIGIN_RATE_LIMIT_WINDOW_SECONDS", "1")),
+)
+UNCACHED_QUERY_RATE_LIMIT = max(
+    1,
+    int(os.getenv("UNCACHED_QUERY_RATE_LIMIT", "10")),
+)
+POINT_MISS_RATE_LIMIT = max(
+    1,
+    int(os.getenv("POINT_MISS_RATE_LIMIT", "20")),
+)
+NEGATIVE_CACHE_TIMEOUT = max(
+    1,
+    int(os.getenv("NEGATIVE_CACHE_TIMEOUT", "15")),
+)
+NEGATIVE_CACHE_MAX_ENTRIES = max(
+    1,
+    int(os.getenv("NEGATIVE_CACHE_MAX_ENTRIES", "1024")),
+)
+POINT_MISS_RATE_BUCKET = "cve_point_miss"
 
 
 class CacheBackendUnavailable(RuntimeError):
     """Signal that Redis is unavailable and origin load must be shed."""
+
+
+class OriginRateLimitExceeded(RuntimeError):
+    """Signal that a shared origin-work budget has been exhausted."""
 
 
 class _SingleflightEntry:
@@ -164,8 +192,11 @@ class CacheManager:
         circuit_breaker_seconds=None,
         singleflight_wait_seconds=None,
         time_func=None,
+        wall_time_func=None,
+        negative_cache_ttl=None,
+        negative_cache_max_entries=None,
     ):
-        """Initialize Redis access with a short per-worker failure circuit."""
+        """Initialize bounded Redis admission and local negative caching."""
         self.redis_client = redis_connection
         self.circuit_breaker_seconds = (
             float(os.getenv("CACHE_CIRCUIT_BREAKER_SECONDS", "1"))
@@ -178,9 +209,22 @@ class CacheManager:
             else max(0.0, float(singleflight_wait_seconds))
         )
         self._time = time.monotonic if time_func is None else time_func
+        self._wall_time = time.time if wall_time_func is None else wall_time_func
         self._unavailable_until = 0.0
         self._singleflight_entries = {}
         self._singleflight_guard = threading.Lock()
+        self.negative_cache_ttl = (
+            NEGATIVE_CACHE_TIMEOUT
+            if negative_cache_ttl is None
+            else max(0.0, float(negative_cache_ttl))
+        )
+        self.negative_cache_max_entries = (
+            NEGATIVE_CACHE_MAX_ENTRIES
+            if negative_cache_max_entries is None
+            else max(1, int(negative_cache_max_entries))
+        )
+        self._negative_entries = OrderedDict()
+        self._negative_guard = threading.Lock()
 
     def _ensure_backend_available(self):
         """Fail fast while the Redis failure circuit remains open."""
@@ -196,7 +240,7 @@ class CacheManager:
         self._unavailable_until = 0.0
 
     @contextmanager
-    def singleflight(self, key):
+    def singleflight(self, key, wait_seconds=None):
         """Yield whether this request acquired the bounded fill slot for key."""
         with self._singleflight_guard:
             entry = self._singleflight_entries.get(key)
@@ -205,7 +249,12 @@ class CacheManager:
                 self._singleflight_entries[key] = entry
             entry.users += 1
 
-        acquired = entry.lock.acquire(timeout=self.singleflight_wait_seconds)
+        wait_timeout = (
+            self.singleflight_wait_seconds
+            if wait_seconds is None
+            else max(0.0, float(wait_seconds))
+        )
+        acquired = entry.lock.acquire(timeout=wait_timeout)
         try:
             yield acquired
         finally:
@@ -215,6 +264,77 @@ class CacheManager:
                 entry.users -= 1
                 if entry.users == 0:
                     self._singleflight_entries.pop(key, None)
+
+    def enforce_rate_limit(self, bucket, limit, window_seconds=None):
+        """Atomically admit one unit of origin work in a shared Redis window."""
+        if limit is None:
+            return
+
+        self._ensure_backend_available()
+        window = max(
+            1,
+            int(
+                RATE_LIMIT_WINDOW_SECONDS
+                if window_seconds is None
+                else window_seconds
+            ),
+        )
+        window_id = int(self._wall_time() // window)
+        safe_bucket = normalize_cache_key_prefix(bucket)
+        counter_key = sanitize_cache_key(
+            f"origin_rate_{safe_bucket}_{window_id}"
+        )
+        try:
+            pipeline = self.redis_client.pipeline(transaction=True)
+            pipeline.incr(counter_key)
+            pipeline.expire(counter_key, window * 2)
+            count, _ = pipeline.execute()
+        except RedisError as exc:
+            self._mark_backend_unavailable()
+            raise CacheBackendUnavailable("Redis admission check failed") from exc
+
+        self._mark_backend_available()
+        if int(count) > max(1, int(limit)):
+            raise OriginRateLimitExceeded(
+                f"Origin rate limit exceeded for {safe_bucket}"
+            )
+
+    def has_negative(self, key):
+        """Return whether a bounded local miss entry remains active."""
+        safe_key = sanitize_cache_key(key)
+        now = self._time()
+        with self._negative_guard:
+            self._prune_negative_entries(now)
+            expires_at = self._negative_entries.get(safe_key)
+            if expires_at is None or expires_at <= now:
+                self._negative_entries.pop(safe_key, None)
+                return False
+            self._negative_entries.move_to_end(safe_key)
+            return True
+
+    def remember_negative(self, key):
+        """Remember one miss without allowing attacker-controlled memory growth."""
+        if self.negative_cache_ttl <= 0:
+            return
+
+        safe_key = sanitize_cache_key(key)
+        now = self._time()
+        with self._negative_guard:
+            self._prune_negative_entries(now)
+            self._negative_entries[safe_key] = now + self.negative_cache_ttl
+            self._negative_entries.move_to_end(safe_key)
+            while len(self._negative_entries) > self.negative_cache_max_entries:
+                self._negative_entries.popitem(last=False)
+
+    def _prune_negative_entries(self, now):
+        """Remove expired local misses while the negative-cache lock is held."""
+        expired_keys = [
+            key
+            for key, expires_at in self._negative_entries.items()
+            if expires_at <= now
+        ]
+        for key in expired_keys:
+            self._negative_entries.pop(key, None)
 
     def get(self, key):
         """Retrieve data from the cache by key."""
@@ -292,6 +412,11 @@ def kev_cache(
     canonical_args=None,
     include_path=True,
     cache_if=None,
+    uncached_rate_limit=None,
+    miss_rate_limit=None,
+    rate_limit_bucket=None,
+    rate_limit_window=RATE_LIMIT_WINDOW_SECONDS,
+    negative_timeout=NEGATIVE_CACHE_TIMEOUT,
 ):
     """Cache Flask responses using route-aware, optionally canonical query keys.
 
@@ -303,8 +428,9 @@ def kev_cache(
     ``canonical_args`` performs the same validation and normalization for path
     arguments. ``include_path=False`` lets public aliases share one logical
     cache entry. ``cache_if`` receives the canonical query items and can bypass
-    caching for valid high-cardinality requests; those handlers remain
-    responsible for applying backend admission control.
+    caching for valid high-cardinality requests. Uncached variants and cache
+    misses can use separate shared Redis admission budgets so multiple workers
+    cannot collectively overwhelm MongoDB.
     """
     def decorator(func):
         @functools.wraps(func)
@@ -345,17 +471,6 @@ def kev_cache(
             elif query_string and has_request_context():
                 query_items = list(request.args.lists())
 
-            # Valid requests outside the bounded cache policy still execute,
-            # but they do not consume Redis or singleflight cardinality.
-            if callable(cache_if) and not cache_if(query_items):
-                try:
-                    return func(*args, **kwargs)
-                except PyMongoError:
-                    return make_response(
-                        {"error": "Backend temporarily unavailable"},
-                        503,
-                    )
-
             cache_context = {
                 "method_args": method_args,
                 "kwargs": cache_kwargs,
@@ -367,6 +482,43 @@ def kev_cache(
                 f"{func.__module__}.{func.__qualname__}",
                 cache_context,
             )
+
+            admission_bucket = rate_limit_bucket or (
+                f"{func.__module__}_{func.__qualname__}"
+            )
+
+            # Uncached variants still share one zero-wait fill slot per exact
+            # query and one cross-worker budget for the broader route family.
+            if callable(cache_if) and not cache_if(query_items):
+                with cache_manager.singleflight(
+                    f"uncached_{cache_key}",
+                    wait_seconds=0,
+                ) as acquired:
+                    if not acquired:
+                        return make_response(
+                            {"error": "Origin temporarily busy"},
+                            503,
+                        )
+                    try:
+                        cache_manager.enforce_rate_limit(
+                            admission_bucket,
+                            uncached_rate_limit,
+                            rate_limit_window,
+                        )
+                    except OriginRateLimitExceeded:
+                        return _rate_limit_response(rate_limit_window)
+                    except CacheBackendUnavailable:
+                        return make_response(
+                            {"error": "Cache temporarily unavailable"},
+                            503,
+                        )
+                    try:
+                        return func(*args, **kwargs)
+                    except PyMongoError:
+                        return make_response(
+                            {"error": "Backend temporarily unavailable"},
+                            503,
+                        )
 
             # Debug: print cache key
             # print(f"[kev_cache] Cache key: {cache_key}")
@@ -403,6 +555,20 @@ def kev_cache(
                     return cached_data
 
                 try:
+                    cache_manager.enforce_rate_limit(
+                        admission_bucket,
+                        miss_rate_limit,
+                        rate_limit_window,
+                    )
+                except OriginRateLimitExceeded:
+                    return _rate_limit_response(rate_limit_window)
+                except CacheBackendUnavailable:
+                    return make_response(
+                        {"error": "Cache temporarily unavailable"},
+                        503,
+                    )
+
+                try:
                     result = func(*args, **kwargs)
                 except PyMongoError:
                     return make_response(
@@ -414,7 +580,19 @@ def kev_cache(
                 response = make_response(result)
                 # Server errors are transient and must not outlive recovery.
                 if response.status_code < 500:
-                    cache_manager.set(cache_key, response, timeout=timeout)
+                    cache_timeout = (
+                        min(timeout, negative_timeout)
+                        if response.status_code >= 400
+                        else timeout
+                    )
+                    cache_manager.set(cache_key, response, timeout=cache_timeout)
                 return result
         return wrapper
     return decorator
+
+
+def _rate_limit_response(window_seconds):
+    """Return a retryable response without exposing admission internals."""
+    response = make_response({"error": "Origin rate limit exceeded"}, 429)
+    response.headers["Retry-After"] = str(max(1, int(window_seconds)))
+    return response

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import re
 import unicodedata
 from urllib.parse import unquote
@@ -7,7 +8,11 @@ ALNUM_SPACE_HYPHEN_UNDERSCORE_RE = re.compile(r"[^\w\s-]+", re.UNICODE)
 EXTRA_WHITESPACE_RE = re.compile(r"\s+", re.UNICODE)
 CVE_RE = re.compile(r"\bcve\b", re.IGNORECASE)
 # Pattern to validate proper CVE ID format
-CVE_ID_FORMAT_RE = re.compile(r"^CVE-\d{4}-\d+$", re.IGNORECASE)
+CVE_ID_FORMAT_RE = re.compile(
+    r"^CVE-([0-9]{4})-([0-9]{4,10})$",
+    re.IGNORECASE,
+)
+MIN_CVE_YEAR = 1999
 # SQL Injection patterns - simplified to just include UNION
 SQL_INJECTION_RE = re.compile(
     r"\b("
@@ -96,14 +101,31 @@ def sanitize_query(query):
 def normalize_cve_id(query):
     """Return one canonical CVE identifier or reject the supplied value.
 
-    Sanitization alone can transform malformed input into a different valid
-    identifier. Requiring the sanitized value to match the complete CVE format
-    ensures cache identity and database identity use the same validated value.
+    Validate before applying any lossy character filtering so punctuation or
+    operator-like input cannot be silently transformed into a different CVE.
+    The year and sequence bounds also keep attacker-generated miss namespaces
+    finite while allowing the documented CVE identifier range.
     """
-    sanitized_query = sanitize_query(query)
-    if not sanitized_query or not CVE_ID_FORMAT_RE.fullmatch(sanitized_query):
+    if query is None:
         raise ValueError("Invalid CVE ID")
-    return sanitized_query.upper()
+
+    normalized_query = str(query).strip()
+    for _ in range(5):
+        decoded_query = unquote(normalized_query)
+        if decoded_query == normalized_query:
+            break
+        normalized_query = decoded_query
+    normalized_query = unicodedata.normalize("NFKC", normalized_query)
+
+    match = CVE_ID_FORMAT_RE.fullmatch(normalized_query)
+    if match is None:
+        raise ValueError("Invalid CVE ID")
+
+    year = int(match.group(1))
+    maximum_year = datetime.now(timezone.utc).year + 1
+    if year < MIN_CVE_YEAR or year > maximum_year:
+        raise ValueError("Invalid CVE ID")
+    return normalized_query.upper()
 
 
 def canonical_cve_arguments(*args, **kwargs):


### PR DESCRIPTION
## Summary

Remediates the five accepted service-impact findings from the repository security review. The review did not identify a reachable MongoDB operator/regex injection, cache-identity bypass, or Host-based cache-poisoning path.

## Findings, impact, and fixes

### 1. Uncached list variants permit repeated expensive MongoDB work (Medium)

**Impact:** Anonymous search, actor, deep-page, and non-default page-size requests bypassed the bounded Redis cache policy and could repeatedly execute an exact MongoDB count plus a paginated query.

**Fix:** Uncached variants now use a zero-wait per-query singleflight and a Redis-coordinated route budget before origin work. Exhausted budgets return `429` with `Retry-After`; Redis admission failures fail closed with `503` instead of falling through to MongoDB.

### 2. Manual point caches repeatedly query MongoDB for arbitrary misses (Medium)

**Impact:** `/kev/<id>` and `/vuln/<id>` accepted lossy-sanitized identifiers and did not remember misses, allowing repeated public requests to consume MongoDB slots.

**Fix:** Both resource families now require exact canonical CVE IDs, use namespaced cache keys, share a cross-worker miss budget, and keep a TTL- and size-bounded per-worker negative cache. Identical concurrent fills remain coalesced.

### 3. High-cardinality negative CVE lookups can churn Redis and MongoDB (Low)

**Impact:** Syntactically valid but nonexistent CVEs could allocate many function-specific Redis entries and force indexed MongoDB lookups.

**Fix:** CVE normalization now validates the original decoded/NFKC-normalized value without lossy character stripping, requires ASCII digits, bounds years to 1999 through next year, and limits sequence length to 4-10 digits. All point-route cache misses share one Redis admission bucket, and negative responses use a short configurable TTL.

### 4. Crafted graph URLs trigger prolonged browser-driven API request loops (Medium)

**Impact:** Opening `/graph?actor=...&per_page=1` could automatically turn one navigation into a dataset-sized series of uncached regex/count requests.

**Fix:** URL state only prefills controls and requires an explicit search action. Automatic actor and bulk page series stop after 10 pages, and the graph UI enforces a minimum page size of 25.

### 5. Browser pages execute third-party CDN scripts without integrity verification (Low)

**Impact:** A compromised CDN response could execute JavaScript in the KEVin browser origin.

**Fix:** Every external script now has an exact SHA-384 SRI value and anonymous CORS mode; D3 is pinned to 7.9.0. Flask also emits a Content Security Policy plus `nosniff` and referrer-policy headers.

## Deployment controls

These settings are read at process startup and documented in the README:

- `ORIGIN_RATE_LIMIT_WINDOW_SECONDS=1`
- `UNCACHED_QUERY_RATE_LIMIT=10`
- `POINT_MISS_RATE_LIMIT=20`
- `NEGATIVE_CACHE_TIMEOUT=15`
- `NEGATIVE_CACHE_MAX_ENTRIES=1024`

Redis coordinates the request budgets across workers. The negative-entry maximum applies per worker to the manual resource cache.

## Verification

- `env/bin/pytest -q -p no:cacheprovider --tb=short` — 42 passed
- Read-only production MongoDB smoke check (`ping` plus projected reads from both application collections) — passed
- `env/bin/python -m compileall -q kevin.py schema utils tests/security_regression_test.py` — passed
- Parsed the graph inline JavaScript with Node's `Function` constructor — passed
- `git diff --check` — passed
- Commit signature verified as a good SSH signature for `synfinner`

The sanitizer unit test now imports the shared sanitizer directly, so test collection does not initialize the application or mutate database indexes.

## Explicitly out of scope

- Maintenance feed-ingestion response/schema bounds (accepted/ignored for this change)
- Docker build execution from the mutable Git dependency (accepted/ignored for this change)
- Copying `.env` into the private-node Docker image (previously accepted risk)
